### PR TITLE
cli: doctor, setup scripts, and a Ghidra-free getting started path

### DIFF
--- a/.claude/skills/j2c-deobfuscate/SKILL.md
+++ b/.claude/skills/j2c-deobfuscate/SKILL.md
@@ -17,9 +17,18 @@ tooling**, not a one-click decompiler: every real target needs some adaptation
 (reading a decompile, supplying state, extending a harness). Your job as the
 agent is to *drive and adapt* these tools, not just run them.
 
-Repo root: the `j2c-dumper/` directory. Build once before use (see README
-"Quick start"): `jvm/` via gradle, `py/` via uv, `native/` via zig (dynamic
-path only), and `pip install unicorn` in the py venv (emulation path).
+Repo root: the `j2c-dumper/` directory. Build once before use with
+`scripts/setup.sh` (`scripts/setup.ps1` on Windows): `jvm/` via gradle, `py/`
+via uv, `native/` via zig (dynamic path only). For the emulation path also run
+`(cd py && uv pip install unicorn)`, which puts unicorn in the same workspace
+venv (`py/.venv`) setup installed the packages into.
+
+**One interpreter.** Run the CLI through `scripts/j2c ...`; it selects the
+interpreter setup installed into. The two things the CLI does not wrap — the
+emulation harness and the lifter's feature flags — run under that same
+interpreter, written below as `py/.venv/bin/python`
+(`py\.venv\Scripts\python.exe` on Windows). A system `python3 -m ...` would not
+see the packages. `scripts/j2c doctor` reports which interpreter is in use.
 
 ## Pick a path
 
@@ -34,7 +43,7 @@ emulation to extract the C-only secrets the others miss.
 
 ## Path 1 — Dynamic (JVMTI)
 
-One-shot: `python -m j2c_dumper_cli.main recover IN.jar -o clean.jar --run-cmd "java -jar IN.jar"`
+One-shot: `scripts/j2c recover IN.jar -o clean.jar --run-cmd "java -jar IN.jar"`
 (chains parse-jar → inspect-binary → merge-manifest → dynamic-trace → trace-to-bc → rebuild).
 
 Adaptation you will likely need:
@@ -55,7 +64,8 @@ parse-jar → inspect-binary → merge-manifest → (Ghidra headless DumpFromMan
 ```
 Ghidra headless invocation and the lifter flags are in README "Static recovery"
 and "Generality". Disable a misfiring lifter feature with
-`python -m ast_matcher.cli --list-flags` / `--disable <flag>`.
+`py/.venv/bin/python -m ast_matcher.cli --list-flags` / `--disable <flag>`
+(the flags are not exposed by `scripts/j2c static-reverse`).
 
 Adaptation: add an obfuscator **profile** for an unseen variant
 ([`docs/adding-obfuscator-profile.md`](../../docs/adding-obfuscator-profile.md));
@@ -63,7 +73,7 @@ design notes in [`docs/static-reverse-approach.md`](../../docs/static-reverse-ap
 
 ## Path 3 — Emulation (Unicorn + mock JNI)
 
-The tool: `py/native_emulate/j2c_emu.py`. Three commands:
+The tool: `py/.venv/bin/python py/native_emulate/j2c_emu.py`. Three commands:
 - `recover DLL_OR_SO` — list native methods; entry points auto-discovered
   (`Java_*` exports → `JNI_OnLoad` emulation → `--registrar 0x..` / `--binary-json`).
 - `strings DLL --fn 0xADDR` — dump a function's decrypted string constants

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
           cache: gradle
 
       - name: Build CLI distributions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Build CLI distributions

--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ Three complementary recovery paths:
 | Path | Input | Approach |
 |---|---|---|
 | **Dynamic** | obfuscated jar + a runnable command | Attach a JVMTI agent, observe the JNI call stream, lift it back to JVM bytecode |
-| **Static** | obfuscated jar + Ghidra | Locate the JNI method tables in the native blob, decompile each function, lift pseudo-C to JVM bytecode |
+| **Static** | offline manifest + optional Ghidra | Start with generic JNI discovery; when static bodies are needed, decompile each function and lift pseudo-C to JVM bytecode |
 | **Emulation** | obfuscated blob (no run, no Ghidra) | Run the native code under a CPU emulator + mock JNI; recover the method table, dump decrypted constants, and call methods as pure-function oracles |
+
+Offline discovery is a common, **Ghidra-free** first step:
+`parse-jar` reads the JAR declarations, `inspect-binary` inspects JNI entry
+points (direct `Java_*` exports and `RegisterNatives` registrations), and
+`merge-manifest` combines the evidence. The discovery boundary lives in
+[`py/binary_introspect`](py/binary_introspect); broader generic-first coverage
+is being completed on [PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4).
+Ghidra is only a later option when the JAR cannot run and you want pseudo-C
+from which to recover static method bodies.
 
 The dynamic/static paths emit an `out.jar` whose native-method stubs are
 replaced with *best-effort recovered bodies* and whose loader / native-blob
@@ -90,17 +99,23 @@ fine on its own.
   `POP` / `CHECKCAST` / `ACONST_NULL` corrections so the emitted
   sequence verifies under ASM `COMPUTE_FRAMES`.
 
-### Static path
+### Offline discovery (no Ghidra)
 
-- **Disassembly-level table discovery** (`py/binary_introspect/`,
-  `capstone`). Walks the native blob's executable sections, locates
-  every `call qword ptr [reg + 0x6B8]` (the `RegisterNatives` JNI vtable
-  slot), backscans the preceding instructions for PC-relative `lea`s
-  whose targets land in `.text` (= function pointers in the
-  `JNINativeMethod[]` being built on the stack) plus the most recent
-  `mov <nMethods-reg>, imm` (= the table size).
+- **JAR and JNI discovery** (`jar-parser`, `py/binary_introspect/`,
+  `manifest-merge`). `parse-jar`, `inspect-binary`, and `merge-manifest`
+  build `manifest.json` from the JAR declarations and the JNI mechanisms
+  defined by the specification: direct `Java_*` exports and dynamic
+  `RegisterNatives` registrations. This stage does not require a live JVM or
+  Ghidra. The generic discovery implementation lives in
+  [`py/binary_introspect`](py/binary_introspect); broader generic-first
+  coverage is being completed on
+  [PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4).
+
+### Static body recovery (optional Ghidra step)
+
 - **Ghidra decompiler** (`ghidra/scripts/DumpFromManifest.java`,
-  Ghidra Headless). Reads the `(class, method, fnAddr)` triples from
+  Ghidra Headless). Use this later when the JAR cannot run and you want static
+  method bodies. It reads the `(class, method, fnAddr)` triples from
   `manifest.json` and runs Ghidra's p-code decompiler on each address,
   yielding a single `ghidra-dump.json` with one pseudo-C body per
   method.
@@ -348,6 +363,23 @@ completion on hard targets (see the human-pass note above).
 > (`py\.venv\Scripts\python` on Windows). If setup fell back to `pip`, use the
 > interpreter it installed into instead.
 
+### Offline discovery (no live run, no Ghidra)
+
+Start here when the JAR cannot run. These generic discovery stages inspect
+standard JNI exports and `RegisterNatives` registration evidence and produce a
+merged manifest; they do **not** require Ghidra:
+
+```bash
+scripts/j2c parse-jar      in.jar      -o classes.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+scripts/j2c merge-manifest classes.json binary.json -o manifest.json
+```
+
+The generic discovery implementation lives in
+[`py/binary_introspect`](py/binary_introspect); broader generic-first coverage
+is being completed on
+[PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4).
+
 ### Fallback: emulation (no live run, no Ghidra)
 
 **Use this when the jar won't run in your environment** — e.g. you only have the
@@ -382,17 +414,18 @@ Every stage has its own subcommand; see
 
 ## Advanced: static recovery (offline, needs Ghidra)
 
-The static path is **optional** and only needed when you cannot run the jar
-**and** want per-method coverage the emulation fallback doesn't auto-emit. It
-requires **Ghidra 11.x**:
+This is an **optional later step** after the Ghidra-free discovery above. Use
+it only when you cannot run the JAR and want pseudo-C for static method bodies
+that the emulation fallback does not auto-emit. This step requires
+**Ghidra 11.x**:
 
 ```bash
-# 1. Parse jar + introspect binary (no --run-cmd needed)
+# 1. Generic JNI discovery (no --run-cmd and no Ghidra needed)
 scripts/j2c parse-jar      in.jar      -o classes.json
 scripts/j2c inspect-binary natives.bin -o binary.json
 scripts/j2c merge-manifest classes.json binary.json -o manifest.json
 
-# 2. Run Ghidra headless against the native blob
+# 2. Optional: lift static bodies through Ghidra headless
 <GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
     -import natives.bin \
     -scriptPath <repo>/ghidra/scripts \

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ You can run the default recovery path by hand — no coding agent required:
 
 ```bash
 git clone <this repo> && cd c2j-native-deobfuscator
-bash scripts/setup.sh                      # build JVM + Python + native agent
-python3 -m j2c_dumper_cli doctor           # confirm the toolchain is ready
-python3 -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+bash scripts/setup.sh                      # build JVM + Python (+ native agent on x86-64)
+scripts/j2c doctor                         # check versions + build artifacts
+scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 ```
 
-> POSIX examples use `python3` (what a minimal system ships and what
-> `scripts/setup.sh` selects). On Windows use `python`.
+> **Run the CLI through `scripts/j2c`** (`scripts\j2c.ps1` on Windows). Setup
+> installs the Python workspace into `py/.venv` (via `uv`), so a bare
+> `python3 -m j2c_dumper_cli` on the *system* interpreter would not find the
+> packages. The launcher picks the interpreter that actually has them.
 
 See [Quick start](#quick-start) below and the
 [10-minute getting-started guide](docs/getting-started.md)
@@ -278,7 +280,7 @@ New here? Follow the [10-minute getting-started guide](docs/getting-started.md)
 
 ```bash
 # Idempotent: builds the JVM modules, syncs the Python workspace, and builds
-# the native agent when a JDK + zig are present. Safe to re-run.
+# the native agent when a JDK + zig are present on an x86-64 host. Safe to re-run.
 bash scripts/setup.sh            # Linux / macOS
 # Windows (PowerShell):
 #   pwsh scripts/setup.ps1
@@ -287,12 +289,14 @@ bash scripts/setup.sh            # Linux / macOS
 `scripts/setup.sh` uses [`uv`](https://docs.astral.sh/uv/) for the Python
 workspace when available and falls back to `pip install -e` otherwise. The
 native agent step needs a JDK and `zig`; it is skipped with a clear message if
-either is missing (only the dynamic path needs it).
+either is missing (only the dynamic path needs it). `native/build.sh` targets
+x86-64, so on ARM (or any other CPU) setup skips the native agent and does not
+report the dynamic path as ready — use the emulation fallback there.
 
 ### 2. Check your toolchain
 
 ```bash
-python3 -m j2c_dumper_cli doctor
+scripts/j2c doctor       # Windows:  scripts\j2c.ps1 doctor
 ```
 
 `doctor` reports Java/JDK, Python, the importability of the Python recover
@@ -310,7 +314,7 @@ JVMTI agent to a live run, observes the JNI call stream, and lifts it back to
 bytecode:
 
 ```bash
-python3 -m j2c_dumper_cli recover \
+scripts/j2c recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -330,8 +334,11 @@ during the run*. Dynamic tracing only covers executed paths, so unobserved
 methods may keep a stub or a partial body; inspect the result and expect manual
 completion on hard targets (see the human-pass note above).
 
-> `python3 -m j2c_dumper_cli ...` is the friendly entry point;
-> `python3 -m j2c_dumper_cli.main ...` still works too.
+> `scripts/j2c ...` runs the CLI through the interpreter setup installed the
+> packages into (the `uv` venv under `py/.venv`, or the `pip`-fallback
+> interpreter). If you activate that environment yourself, the equivalent
+> `python3 -m j2c_dumper_cli ...` (or `python3 -m j2c_dumper_cli.main ...`) works
+> too — the launcher just saves you from picking the wrong interpreter.
 
 ### Fallback: emulation (no live run, no Ghidra)
 
@@ -359,7 +366,7 @@ command reference + verified matrix: [`py/native_emulate/README.md`](py/native_e
 ### Stage-by-stage
 
 Every stage has its own subcommand; see
-`python3 -m j2c_dumper_cli --help` for the full list.
+`scripts/j2c --help` for the full list.
 
 ---
 
@@ -371,9 +378,9 @@ requires **Ghidra 11.x**:
 
 ```bash
 # 1. Parse jar + introspect binary (no --run-cmd needed)
-python3 -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
-python3 -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
-python3 -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
+scripts/j2c parse-jar      in.jar      -o classes.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+scripts/j2c merge-manifest classes.json binary.json -o manifest.json
 
 # 2. Run Ghidra headless against the native blob
 <GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
@@ -383,7 +390,7 @@ python3 -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.js
 
 # 3. Lift the pseudo-C to bytecode + rebuild
 python3 -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
-python3 -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
+scripts/j2c rebuild --input in.jar --recovered recovered/ \
     --manifest manifest.json -o out.jar
 ```
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ blob, or you need the decrypted C-only constants. It runs the native code under
 a CPU emulator with a mock JNI; no JVM and no Ghidra required:
 
 ```bash
-# add unicorn to the workspace interpreter (pip fallback: python3 -m pip install unicorn)
+# add unicorn to the workspace interpreter (`scripts/j2c doctor` prints the
+# exact command if setup fell back to pip)
 (cd py && uv pip install unicorn)
 
 # list native methods (entry points auto-discovered)

--- a/README.md
+++ b/README.md
@@ -25,21 +25,33 @@ License: **GPLv3**.
 
 ---
 
-## ⭐ Recommended workflow: drive it with a coding agent
+## Run it yourself
 
-**The best way to use this project is to load the bundled skill
-([`.claude/skills/j2c-deobfuscate`](.claude/skills/j2c-deobfuscate/SKILL.md))
-into your favourite coding agent and let it do the work.**
+You can run the default recovery path by hand — no coding agent required:
 
-This project gives you a **universal approach + tooling** for the whole
-"transpile Java → C/C++ and call back via JNI" obfuscator family — but a
-universal approach unavoidably needs some adaptation to each specific target
+```bash
+git clone <this repo> && cd c2j-native-deobfuscator
+bash scripts/setup.sh                     # build JVM + Python + native agent
+python -m j2c_dumper_cli doctor           # confirm the toolchain is ready
+python -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+```
+
+See [Quick start](#quick-start) below and the
+[10-minute getting-started guide](docs/getting-started.md)
+([中文](docs/getting-started.zh-CN.md)).
+
+**When the auto-output needs a human pass.** This project is a *universal*
+approach for the whole "transpile Java → C/C++ and call back via JNI"
+obfuscator family, so hard targets can still need per-method adaptation
 (reading a decompile, supplying per-method state, extending a harness, adding a
-profile). Today's AI agents handle exactly this kind of adaptation well.
+profile). For those, the recovered `*.json` intermediates are meant to be
+hand-edited — see [`docs/manual-restoration.md`](docs/manual-restoration.md).
 
-So **don't expect to just run the ready-made scripts by hand.** Without that
-human/agent fix-up step, the results will be partial — not impressive. Hand the
-agent the skill and the target, and let it adapt the tools to the binary.
+**Optional:** a coding agent handles that adaptation well. If you use one, load
+the bundled skill
+([`.claude/skills/j2c-deobfuscate`](.claude/skills/j2c-deobfuscate/SKILL.md))
+and hand it the target. This is a convenience, not a requirement — the CLI runs
+fine on its own.
 
 ---
 
@@ -253,26 +265,43 @@ render them.
 
 ## Quick start
 
-### One-time build
+Prerequisites: **JDK 21+** (with `JAVA_HOME` set) and **Python 3.11+**.
+New here? Follow the [10-minute getting-started guide](docs/getting-started.md)
+([中文](docs/getting-started.zh-CN.md)).
+
+### 1. Install (build everything)
 
 ```bash
-# JVM modules
-cd jvm && ./gradlew installDist
-
-# Python workspace
-cd py && uv sync --all-packages
-
-# Native agent (only needed for the dynamic path)
-cd native && JDK_HOME="$JAVA_HOME" bash build.sh
-
-# Emulation path
-cd py && .venv/Scripts/python -m pip install unicorn   # or your venv's pip
+# Idempotent: builds the JVM modules, syncs the Python workspace, and builds
+# the native agent when a JDK + zig are present. Safe to re-run.
+bash scripts/setup.sh            # Linux / macOS
+# Windows (PowerShell):
+#   pwsh scripts/setup.ps1
 ```
 
-### Dynamic recovery (preferred when the jar runs in your environment)
+`scripts/setup.sh` uses [`uv`](https://docs.astral.sh/uv/) for the Python
+workspace when available and falls back to `pip install -e` otherwise. The
+native agent step needs a JDK and `zig`; it is skipped with a clear message if
+either is missing (only the dynamic path needs it).
+
+### 2. Check your toolchain
 
 ```bash
-python -m j2c_dumper_cli.main recover \
+python -m j2c_dumper_cli doctor
+```
+
+`doctor` reports Java/JDK, Python, the built JVM modules and native agent, and
+the optional tools (Ghidra, unicorn, zig), and prints the next command for
+anything missing. It exits non-zero until the default path is ready.
+
+### 3. Recover (default path — dynamic)
+
+**Use this when the jar can be launched in your environment.** It attaches the
+JVMTI agent to a live run, observes the JNI call stream, and lifts it back to
+bytecode:
+
+```bash
+python -m j2c_dumper_cli recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -287,29 +316,18 @@ This chains:
 5. `trace-to-bc`       lifts to `recovered/*.json`
 6. `rebuild`           emits the loader-stripped output jar
 
-### Static recovery (when you can't run the jar — needs Ghidra)
+> `python -m j2c_dumper_cli ...` is the friendly entry point;
+> `python -m j2c_dumper_cli.main ...` still works too.
+
+### Fallback: emulation (no live run, no Ghidra)
+
+**Use this when the jar won't run in your environment** — e.g. you only have the
+blob, or you need the decrypted C-only constants. It runs the native code under
+a CPU emulator with a mock JNI; no JVM and no Ghidra required:
 
 ```bash
-# 1. Parse jar + introspect binary as above (no --run-cmd needed)
-python -m j2c_dumper_cli.main parse-jar      in.jar      -o classes.json
-python -m j2c_dumper_cli.main inspect-binary natives.bin -o binary.json
-python -m j2c_dumper_cli.main merge-manifest classes.json binary.json -o manifest.json
+pip install unicorn
 
-# 2. Run Ghidra headless against the native blob
-<GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
-    -import natives.bin \
-    -scriptPath <repo>/ghidra/scripts \
-    -postScript DumpFromManifest.java manifest.json ghidra-dump.json
-
-# 3. Lift the pseudo-C to bytecode + rebuild
-python -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
-python -m j2c_dumper_cli.main rebuild --input in.jar --recovered recovered/ \
-    --manifest manifest.json -o out.jar
-```
-
-### Emulation recovery (no JVM, no Ghidra — for C-rewritten logic / decrypted constants)
-
-```bash
 # list native methods (entry points auto-discovered)
 python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 
@@ -326,8 +344,34 @@ command reference + verified matrix: [`py/native_emulate/README.md`](py/native_e
 
 ### Stage-by-stage
 
-Every stage has its own subcommand under `j2c-dumper`; see
-`python -m j2c_dumper_cli.main --help` for the full list.
+Every stage has its own subcommand; see
+`python -m j2c_dumper_cli --help` for the full list.
+
+---
+
+## Advanced: static recovery (offline, needs Ghidra)
+
+The static path is **optional** and only needed when you cannot run the jar
+**and** want per-method coverage the emulation fallback doesn't auto-emit. It
+requires **Ghidra 11.x**:
+
+```bash
+# 1. Parse jar + introspect binary (no --run-cmd needed)
+python -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
+python -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
+python -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
+
+# 2. Run Ghidra headless against the native blob
+<GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
+    -import natives.bin \
+    -scriptPath <repo>/ghidra/scripts \
+    -postScript DumpFromManifest.java manifest.json ghidra-dump.json
+
+# 3. Lift the pseudo-C to bytecode + rebuild
+python -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
+python -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
+    --manifest manifest.json -o out.jar
+```
 
 ---
 
@@ -389,6 +433,8 @@ python -m ast_matcher.cli --list-flags
 
 ## Documentation
 
+- [getting-started.md](docs/getting-started.md) — 10-minute default-path
+  walkthrough, common failures, where the JSON artifacts land
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — module boundaries, pipeline,
   artifact schemas, extension points
 - [emulation-recovery.md](docs/emulation-recovery.md) — emulation path how-to

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ Three complementary recovery paths:
 | **Static** | obfuscated jar + Ghidra | Locate the JNI method tables in the native blob, decompile each function, lift pseudo-C to JVM bytecode |
 | **Emulation** | obfuscated blob (no run, no Ghidra) | Run the native code under a CPU emulator + mock JNI; recover the method table, dump decrypted constants, and call methods as pure-function oracles |
 
-The dynamic/static paths emit a clean `out.jar` whose native methods now have
-real bytecode bodies and whose loader / native-blob entries are stripped. The
-emulation path recovers the C-only secrets the other two can't see (inlined
-comparisons, the `<clinit>` string tables) and gives you an executable oracle.
+The dynamic/static paths emit an `out.jar` whose native-method stubs are
+replaced with *best-effort recovered bodies* and whose loader / native-blob
+entries are stripped. Coverage is per method: the dynamic path recovers the
+paths a run actually executes, the static path what the decompile lifts
+cleanly — so unobserved or unlifted methods may keep a stub or a partial body.
+Inspect the output and expect manual completion on hard targets. The emulation
+path recovers the C-only secrets the other two can't see (inlined comparisons,
+the `<clinit>` string tables) and gives you an executable oracle.
 
 License: **GPLv3**.
 
@@ -158,7 +162,7 @@ All three target the same input but trade off coverage versus accuracy:
 | | Dynamic | Static | Emulation |
 |---|---|---|---|
 | **Best fit** | Binary is packed / VM-protected / has anti-debug — the JVMTI agent sits at the Java side of the wall so the native protection layer doesn't matter. | Binary is unprotected (e.g. straight native-obfuscator + zig c++ output). Ghidra can decompile each `fnAddr` directly. | Logic is rewritten to pure C (comparisons / crypto / string tables), or the jar won't run **and** Ghidra can't structure the code, or you need the decrypted constants. |
-| **Requires** | A runnable command line (`java -jar ...`) that exercises the obfuscated classes. | Ghidra 11.x installed. | Just the blob + `pip install unicorn`. No JVM, no Ghidra. |
+| **Requires** | A runnable command line (`java -jar ...`) that exercises the obfuscated classes. | Ghidra 11.x installed. | Just the blob + the `unicorn` package. No JVM, no Ghidra. |
 | **Coverage** | Only branches you actually run. | Every method registered through `RegisterNatives`. | Method list + decrypted constants always; per-method behaviour via the oracle. |
 | **Accuracy** | High — every opcode maps to an observed JNI call. | Best-effort — pattern matching on decompiled C, stubs on stack imbalance. | Exact (it executes the real code), but you reverse the algorithm from oracle I/O — it does **not** auto-emit bytecode. |
 | **Speed** | Target run time + agent overhead. | Ghidra auto-analysis (minutes for ~1 MB blobs). | Fast — no Ghidra, no live JVM. |
@@ -305,7 +309,9 @@ agent, plus the optional tools (Ghidra, unicorn, zig), and prints the next
 command for anything missing. It verifies tool versions and artifact presence —
 it does not launch the JVM modules or load the agent. It exits non-zero only
 when a required piece is *missing*; a `WARN` (e.g. `JAVA_HOME` unset) is a
-caveat, not a blocker.
+caveat, not a blocker. The agent must match this host in both name and CPU: on a
+non-x86-64 host, where `native/build.sh` cannot produce a loadable agent, it is
+always reported missing and the dynamic path is not ready.
 
 ### 3. Recover (default path — dynamic)
 
@@ -334,11 +340,13 @@ during the run*. Dynamic tracing only covers executed paths, so unobserved
 methods may keep a stub or a partial body; inspect the result and expect manual
 completion on hard targets (see the human-pass note above).
 
-> `scripts/j2c ...` runs the CLI through the interpreter setup installed the
-> packages into (the `uv` venv under `py/.venv`, or the `pip`-fallback
-> interpreter). If you activate that environment yourself, the equivalent
-> `python3 -m j2c_dumper_cli ...` (or `python3 -m j2c_dumper_cli.main ...`) works
-> too — the launcher just saves you from picking the wrong interpreter.
+> **One interpreter.** `scripts/j2c ...` runs the CLI through the interpreter
+> setup installed the packages into (the `uv` venv at `py/.venv`, or the
+> `pip`-fallback interpreter), so you never have to pick one. The few things the
+> CLI does not wrap — the emulation harness and the lifter's feature flags below
+> — run under that same interpreter, written here as `py/.venv/bin/python`
+> (`py\.venv\Scripts\python` on Windows). If setup fell back to `pip`, use the
+> interpreter it installed into instead.
 
 ### Fallback: emulation (no live run, no Ghidra)
 
@@ -347,16 +355,17 @@ blob, or you need the decrypted C-only constants. It runs the native code under
 a CPU emulator with a mock JNI; no JVM and no Ghidra required:
 
 ```bash
-pip install unicorn
+# add unicorn to the workspace interpreter (pip fallback: python3 -m pip install unicorn)
+(cd py && uv pip install unicorn)
 
 # list native methods (entry points auto-discovered)
-python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 
 # dump a function's decrypted string constants (alphabet, secret, messages)
-python3 py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
+py/.venv/bin/python py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
 
 # call a native method as a pure function (oracle)
-python3 py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
+py/.venv/bin/python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
     --arg-bytes "input" --static "v=@alphabet.txt"
 ```
 
@@ -389,7 +398,7 @@ scripts/j2c merge-manifest classes.json binary.json -o manifest.json
     -postScript DumpFromManifest.java manifest.json ghidra-dump.json
 
 # 3. Lift the pseudo-C to bytecode + rebuild
-python3 -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
+scripts/j2c static-reverse ghidra-dump.json --manifest manifest.json -o recovered/
 scripts/j2c rebuild --input in.jar --recovered recovered/ \
     --manifest manifest.json -o out.jar
 ```
@@ -412,11 +421,14 @@ feature flag (throw-reason hint parsing, ExceptionCheck-guard skipping,
 symbol-table tracking, lookup-table resolution, etc.). Disable a flag
 when it misbehaves on a specific binary:
 
+The flags are not exposed by `scripts/j2c static-reverse`, so drive the lifter
+directly with the workspace interpreter:
+
 ```bash
-python3 -m ast_matcher.cli ghidra-dump.json -o recovered/ \
+py/.venv/bin/python -m ast_matcher.cli ghidra-dump.json -o recovered/ \
     --disable use_throw_reason_invoke_hints \
     --disable skip_native_exception_guards
-python3 -m ast_matcher.cli --list-flags
+py/.venv/bin/python -m ast_matcher.cli --list-flags
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ You can run the default recovery path by hand — no coding agent required:
 
 ```bash
 git clone <this repo> && cd c2j-native-deobfuscator
-bash scripts/setup.sh                     # build JVM + Python + native agent
-python -m j2c_dumper_cli doctor           # confirm the toolchain is ready
-python -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+bash scripts/setup.sh                      # build JVM + Python + native agent
+python3 -m j2c_dumper_cli doctor           # confirm the toolchain is ready
+python3 -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 ```
+
+> POSIX examples use `python3` (what a minimal system ships and what
+> `scripts/setup.sh` selects). On Windows use `python`.
 
 See [Quick start](#quick-start) below and the
 [10-minute getting-started guide](docs/getting-started.md)
@@ -265,7 +268,9 @@ render them.
 
 ## Quick start
 
-Prerequisites: **JDK 21+** (with `JAVA_HOME` set) and **Python 3.11+**.
+Prerequisites: **JDK 17+** (with `JAVA_HOME` set) and **Python 3.11+**. On
+Windows, building the native agent also needs **Git Bash** (from Git for
+Windows); WSL builds a Linux `.so`, not the Windows `.dll` the JVM loads here.
 New here? Follow the [10-minute getting-started guide](docs/getting-started.md)
 ([中文](docs/getting-started.zh-CN.md)).
 
@@ -287,12 +292,16 @@ either is missing (only the dynamic path needs it).
 ### 2. Check your toolchain
 
 ```bash
-python -m j2c_dumper_cli doctor
+python3 -m j2c_dumper_cli doctor
 ```
 
-`doctor` reports Java/JDK, Python, the built JVM modules and native agent, and
-the optional tools (Ghidra, unicorn, zig), and prints the next command for
-anything missing. It exits non-zero until the default path is ready.
+`doctor` reports Java/JDK, Python, the importability of the Python recover
+stage (`capstone` + `lief`), the built JVM modules and the host-matching native
+agent, plus the optional tools (Ghidra, unicorn, zig), and prints the next
+command for anything missing. It verifies tool versions and artifact presence —
+it does not launch the JVM modules or load the agent. It exits non-zero only
+when a required piece is *missing*; a `WARN` (e.g. `JAVA_HOME` unset) is a
+caveat, not a blocker.
 
 ### 3. Recover (default path — dynamic)
 
@@ -301,7 +310,7 @@ JVMTI agent to a live run, observes the JNI call stream, and lifts it back to
 bytecode:
 
 ```bash
-python -m j2c_dumper_cli recover \
+python3 -m j2c_dumper_cli recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -316,8 +325,13 @@ This chains:
 5. `trace-to-bc`       lifts to `recovered/*.json`
 6. `rebuild`           emits the loader-stripped output jar
 
-> `python -m j2c_dumper_cli ...` is the friendly entry point;
-> `python -m j2c_dumper_cli.main ...` still works too.
+The output contains *best-effort recovered bodies for the behavior observed
+during the run*. Dynamic tracing only covers executed paths, so unobserved
+methods may keep a stub or a partial body; inspect the result and expect manual
+completion on hard targets (see the human-pass note above).
+
+> `python3 -m j2c_dumper_cli ...` is the friendly entry point;
+> `python3 -m j2c_dumper_cli.main ...` still works too.
 
 ### Fallback: emulation (no live run, no Ghidra)
 
@@ -329,13 +343,13 @@ a CPU emulator with a mock JNI; no JVM and no Ghidra required:
 pip install unicorn
 
 # list native methods (entry points auto-discovered)
-python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 
 # dump a function's decrypted string constants (alphabet, secret, messages)
-python py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
+python3 py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
 
 # call a native method as a pure function (oracle)
-python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
+python3 py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
     --arg-bytes "input" --static "v=@alphabet.txt"
 ```
 
@@ -345,7 +359,7 @@ command reference + verified matrix: [`py/native_emulate/README.md`](py/native_e
 ### Stage-by-stage
 
 Every stage has its own subcommand; see
-`python -m j2c_dumper_cli --help` for the full list.
+`python3 -m j2c_dumper_cli --help` for the full list.
 
 ---
 
@@ -357,9 +371,9 @@ requires **Ghidra 11.x**:
 
 ```bash
 # 1. Parse jar + introspect binary (no --run-cmd needed)
-python -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
-python -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
-python -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
+python3 -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
+python3 -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
+python3 -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
 
 # 2. Run Ghidra headless against the native blob
 <GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
@@ -368,8 +382,8 @@ python -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.jso
     -postScript DumpFromManifest.java manifest.json ghidra-dump.json
 
 # 3. Lift the pseudo-C to bytecode + rebuild
-python -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
-python -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
+python3 -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
+python3 -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
     --manifest manifest.json -o out.jar
 ```
 
@@ -392,10 +406,10 @@ symbol-table tracking, lookup-table resolution, etc.). Disable a flag
 when it misbehaves on a specific binary:
 
 ```bash
-python -m ast_matcher.cli ghidra-dump.json -o recovered/ \
+python3 -m ast_matcher.cli ghidra-dump.json -o recovered/ \
     --disable use_throw_reason_invoke_hints \
     --disable skip_native_exception_guards
-python -m ast_matcher.cli --list-flags
+python3 -m ast_matcher.cli --list-flags
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,8 +12,16 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 | 路径 | 输入 | 思路 |
 |---|---|---|
 | **动态** | 混淆后的 JAR + 一条可运行的命令 | 加载 JVMTI agent，观察 JNI 调用流，把它重新拼回 JVM 字节码 |
-| **静态** | 混淆后的 JAR + Ghidra | 在 native blob 里定位 JNI method table，逐函数反编译，把 pseudo-C 抬升回 JVM 字节码 |
+| **静态** | 离线 manifest + 可选 Ghidra | 先做通用 JNI 发现；需要静态方法体时再逐函数反编译，把 pseudo-C 抬升回 JVM 字节码 |
 | **模拟** | 混淆后的 blob（不需运行、不需 Ghidra） | 用 CPU 模拟器 + mock JNI 直接跑 native 代码：恢复方法表、dump 解密后的常量、把方法当纯函数来调用 |
+
+离线发现是各路径共用的第一步，**不需要 Ghidra**：`parse-jar` 读取 JAR 声明，
+`inspect-binary` 按 JNI 规范检查入口（直接导出的 `Java_*` 符号和
+`RegisterNatives` 动态注册），`merge-manifest` 再合并这些证据。发现边界位于
+[`py/binary_introspect`](py/binary_introspect)；更完整的 generic-first 覆盖正在
+[PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4) 中完成。
+只有当 JAR 无法运行、而你又希望从 pseudo-C 恢复静态方法体时，才需要在后续
+可选地使用 Ghidra。
 
 动态/静态路径会输出一个 `out.jar`：原先的 native 方法桩被替换成*尽力恢复出的方法体*，loader / native blob 资源条目被剥离。覆盖度是按方法计的 —— 动态路径只能恢复本次运行真正执行到的分支，静态路径只能恢复反编译结果能干净抬升的部分，因此未被观察到或未能抬升的方法可能仍是桩或只有部分方法体。请检查产物，难度较大的目标要预期人工补齐。模拟路径则负责挖出另外两条路看不到的"纯 C 秘密"（被内联的比较、`<clinit>` 字符串表），并给你一个可执行的 oracle。
 
@@ -126,18 +134,23 @@ scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
   / `ACONST_NULL`，让最终的字节码可以通过 ASM 的
   `COMPUTE_FRAMES` 校验。
 
-### 静态路径
+### 离线发现（无需 Ghidra）
 
-- **反汇编层的 native 表发现**（`py/binary_introspect/`，`capstone`）。
-  扫描 native blob 的可执行节，定位所有
-  `call qword ptr [reg + 0x6B8]`（`RegisterNatives` 在 JNI vtable 中的偏移）
-  调用点，往前回扫 PC 相对的 `lea`（指向 `.text`，即栈上构造的
-  `JNINativeMethod[]` 里的函数指针）以及最近的
-  `mov <nMethods-reg>, imm`（表长度）。
+- **JAR 与 JNI 发现**（`jar-parser`、`py/binary_introspect/`、
+  `manifest-merge`）。`parse-jar`、`inspect-binary`、`merge-manifest`
+  从 JAR 声明以及 JNI 规范定义的机制构建 `manifest.json`：直接导出的
+  `Java_*` 符号和 `RegisterNatives` 动态注册。这个阶段既不需要活 JVM，也不
+  需要 Ghidra。通用发现实现位于
+  [`py/binary_introspect`](py/binary_introspect)；更完整的 generic-first
+  覆盖正在
+  [PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4) 中完成。
+
+### 静态方法体恢复（可选 Ghidra 步骤）
+
 - **Ghidra 反编译器**（`ghidra/scripts/DumpFromManifest.java`，Ghidra
-  Headless）。读取 `manifest.json` 中的 `(class, method, fnAddr)`，对每个
-  地址跑一次 p-code 反编译，结果汇总到 `ghidra-dump.json`，每个方法对应
-  一段 pseudo-C。
+  Headless）。当 JAR 无法运行、而你又需要静态方法体时，才在后续使用它。
+  它读取 `manifest.json` 中的 `(class, method, fnAddr)`，对每个地址跑一次
+  p-code 反编译，结果汇总到 `ghidra-dump.json`，每个方法对应一段 pseudo-C。
 - **tree-sitter-c AST 解析**（`py/ast_matcher/`，`tree-sitter-c`）。把
   Ghidra 输出的 pseudo-C 解析成 AST，再由按 feature flag 控制的 driver
   识别 `env->FnName(args)` 形式的 JNI 调用（这是从 Ghidra 的
@@ -288,6 +301,21 @@ scripts/j2c recover \
 > 本文写作 `py/.venv/bin/python`（Windows 上为 `py\.venv\Scripts\python`）。如果
 > setup 走的是 `pip` 兜底，就换成它安装到的那个解释器。
 
+### 离线发现（无需运行、无需 Ghidra）
+
+当 JAR 无法运行时先从这里开始。下面的通用发现步骤会检查标准 JNI 导出符号和
+`RegisterNatives` 注册证据，再生成合并后的 manifest；它们**不需要 Ghidra**：
+
+```bash
+scripts/j2c parse-jar      in.jar      -o classes.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+scripts/j2c merge-manifest classes.json binary.json -o manifest.json
+```
+
+通用发现实现位于 [`py/binary_introspect`](py/binary_introspect)；更完整的
+generic-first 覆盖正在
+[PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4) 中完成。
+
 ### 兜底：模拟恢复（无需运行、无需 Ghidra）
 
 **当目标在你环境里跑不起来时用这条** —— 例如你只有 blob，或者你需要那些只藏在
@@ -321,16 +349,17 @@ py/.venv/bin/python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> 
 
 ## 进阶：静态恢复（离线，需要 Ghidra）
 
-静态路径是**可选**的，只有在目标跑不起来**且**你需要模拟兜底不会自动产出的
-逐方法覆盖时才用得上。它需要 **Ghidra 11.x**：
+这是上面无 Ghidra 发现之后的**可选后续步骤**。只有当 JAR 无法运行、而你又需要
+模拟兜底不会自动产出的静态方法体 pseudo-C 时才使用它；这一步需要
+**Ghidra 11.x**：
 
 ```bash
-# 1. 解析 jar + 内省二进制（不需要 --run-cmd）
+# 1. 通用 JNI 发现（不需要 --run-cmd，也不需要 Ghidra）
 scripts/j2c parse-jar      in.jar      -o classes.json
 scripts/j2c inspect-binary natives.bin -o binary.json
 scripts/j2c merge-manifest classes.json binary.json -o manifest.json
 
-# 2. 用 Ghidra Headless 跑 native blob
+# 2. 可选：通过 Ghidra Headless 抬升静态方法体
 <GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
     -import natives.bin \
     -scriptPath <repo>/ghidra/scripts \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,10 +27,13 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 
 ```bash
 git clone <本仓库> && cd c2j-native-deobfuscator
-bash scripts/setup.sh                     # 构建 JVM + Python + native agent
-python -m j2c_dumper_cli doctor           # 确认工具链就绪
-python -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+bash scripts/setup.sh                      # 构建 JVM + Python + native agent
+python3 -m j2c_dumper_cli doctor           # 确认工具链就绪
+python3 -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 ```
+
+> POSIX 示例使用 `python3`（最小化系统自带、也是 `scripts/setup.sh` 选用的解释器）。
+> 在 Windows 上请改用 `python`。
 
 详见下方的 [Quick start](#quick-start) 以及
 [10 分钟上手指南](docs/getting-started.zh-CN.md)
@@ -217,7 +220,9 @@ python -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 
 ## Quick start
 
-前置条件：**JDK 21+**（并设置 `JAVA_HOME`）与 **Python 3.11+**。
+前置条件：**JDK 17+**（并设置 `JAVA_HOME`）与 **Python 3.11+**。在 Windows 上
+构建 native agent 还需要 **Git Bash**（随 Git for Windows 提供）；WSL 会构建出
+Linux 的 `.so`，而不是这里 JVM 加载的 Windows `.dll`。
 第一次上手？请按
 [10 分钟上手指南](docs/getting-started.zh-CN.md)（[English](docs/getting-started.md)）操作。
 
@@ -238,12 +243,14 @@ bash scripts/setup.sh            # Linux / macOS
 ### 2. 检查工具链
 
 ```bash
-python -m j2c_dumper_cli doctor
+python3 -m j2c_dumper_cli doctor
 ```
 
-`doctor` 会报告 Java/JDK、Python、已构建的 JVM 模块与 native agent，以及可选
-工具（Ghidra、unicorn、zig），并为每个缺失项打印下一步命令。默认路径未就绪
-时它会以非零码退出。
+`doctor` 会报告 Java/JDK、Python、Python 恢复阶段是否可 import（`capstone` +
+`lief`）、已构建的 JVM 模块与本机匹配的 native agent，以及可选工具（Ghidra、
+unicorn、zig），并为每个缺失项打印下一步命令。它只校验工具版本与产物是否存在，
+不会启动 JVM 模块或加载 agent。只有当某个必需项**缺失**时它才以非零码退出；
+`WARN`（例如 `JAVA_HOME` 未设）只是提醒，不是阻塞。
 
 ### 3. 恢复（默认路径 —— 动态）
 
@@ -251,7 +258,7 @@ python -m j2c_dumper_cli doctor
 观察 JNI 调用流，再抬升回字节码：
 
 ```bash
-python -m j2c_dumper_cli recover \
+python3 -m j2c_dumper_cli recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -266,8 +273,12 @@ python -m j2c_dumper_cli recover \
 5. `trace-to-bc`       抬升到 `recovered/*.json`
 6. `rebuild`           输出 loader 已剥离的最终 JAR
 
-> `python -m j2c_dumper_cli ...` 是更友好的入口；
-> `python -m j2c_dumper_cli.main ...` 仍然可用。
+输出包含的是**针对本次运行中观察到的行为、尽力恢复出的方法体**。动态 trace 只
+覆盖实际执行到的路径，因此未观察到的方法可能仍是桩或只有部分方法体；请检查结果，
+难度较大的目标要预期需要人工补全（见上文的"人工过一遍"说明）。
+
+> `python3 -m j2c_dumper_cli ...` 是更友好的入口；
+> `python3 -m j2c_dumper_cli.main ...` 仍然可用。
 
 ### 兜底：模拟恢复（无需运行、无需 Ghidra）
 
@@ -279,13 +290,13 @@ python -m j2c_dumper_cli recover \
 pip install unicorn
 
 # 列出 native 方法（入口自动发现）
-python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 
 # dump 某个函数解密后的字符串常量（字母表、密文、提示语）
-python py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
+python3 py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
 
 # 把 native 方法当纯函数调用（oracle）
-python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
+python3 py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
     --arg-bytes "input" --static "v=@alphabet.txt"
 ```
 
@@ -295,7 +306,7 @@ python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
 ### 分阶段执行
 
 每个阶段都有独立的子命令，详见
-`python -m j2c_dumper_cli --help`。
+`python3 -m j2c_dumper_cli --help`。
 
 ---
 
@@ -306,9 +317,9 @@ python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
 
 ```bash
 # 1. 解析 jar + 内省二进制（不需要 --run-cmd）
-python -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
-python -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
-python -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
+python3 -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
+python3 -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
+python3 -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
 
 # 2. 用 Ghidra Headless 跑 native blob
 <GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
@@ -317,8 +328,8 @@ python -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.jso
     -postScript DumpFromManifest.java manifest.json ghidra-dump.json
 
 # 3. pseudo-C 抬升到字节码 + 重建 JAR
-python -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
-python -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
+python3 -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
+python3 -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
     --manifest manifest.json -o out.jar
 ```
 
@@ -340,10 +351,10 @@ hint、ExceptionCheck-guard 跳过、符号表跟踪、查表解析等等）。�
 对当前二进制误判，就把它关掉：
 
 ```bash
-python -m ast_matcher.cli ghidra-dump.json -o recovered/ \
+python3 -m ast_matcher.cli ghidra-dump.json -o recovered/ \
     --disable use_throw_reason_invoke_hints \
     --disable skip_native_exception_guards
-python -m ast_matcher.cli --list-flags
+python3 -m ast_matcher.cli --list-flags
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 | **静态** | 混淆后的 JAR + Ghidra | 在 native blob 里定位 JNI method table，逐函数反编译，把 pseudo-C 抬升回 JVM 字节码 |
 | **模拟** | 混淆后的 blob（不需运行、不需 Ghidra） | 用 CPU 模拟器 + mock JNI 直接跑 native 代码：恢复方法表、dump 解密后的常量、把方法当纯函数来调用 |
 
-动态/静态路径会输出一个干净的 `out.jar`：原先的 native 方法现在拥有真实的字节码方法体，loader / native blob 资源条目被剥离。模拟路径则负责挖出另外两条路看不到的"纯 C 秘密"（被内联的比较、`<clinit>` 字符串表），并给你一个可执行的 oracle。
+动态/静态路径会输出一个 `out.jar`：原先的 native 方法桩被替换成*尽力恢复出的方法体*，loader / native blob 资源条目被剥离。覆盖度是按方法计的 —— 动态路径只能恢复本次运行真正执行到的分支，静态路径只能恢复反编译结果能干净抬升的部分，因此未被观察到或未能抬升的方法可能仍是桩或只有部分方法体。请检查产物，难度较大的目标要预期人工补齐。模拟路径则负责挖出另外两条路看不到的"纯 C 秘密"（被内联的比较、`<clinit>` 字符串表），并给你一个可执行的 oracle。
 
 协议：**GPLv3**。
 
@@ -188,7 +188,7 @@ scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 | | 动态 | 静态 | 模拟 |
 |---|---|---|---|
 | **适合的场景** | 二进制被加壳 / 虚拟机保护 / 反调试 —— JVMTI agent 工作在 Java 侧，native 层的保护不影响它的可见性。 | 二进制未经额外保护（例如直接 native-obfuscator + zig c++ 输出），Ghidra 能直接反编译每个 `fnAddr`。 | 逻辑被改写成纯 C（比较 / 加密 / 字符串表），或者 jar 跑不起来**且** Ghidra 结构化不了，或者你需要解密后的常量。 |
-| **要求** | 一条可执行的命令（`java -jar ...`），并且能跑到目标类。 | 安装了 Ghidra 11.x。 | 只要 blob + `pip install unicorn`。不需要 JVM，不需要 Ghidra。 |
+| **要求** | 一条可执行的命令（`java -jar ...`），并且能跑到目标类。 | 安装了 Ghidra 11.x。 | 只要 blob + `unicorn` 包。不需要 JVM，不需要 Ghidra。 |
 | **覆盖率** | 只覆盖实际被执行到的分支；从未被调用的方法完全采集不到。 | 通过 `RegisterNatives` 注册的所有方法，无论运行时是否被触发。 | 方法表 + 解密常量总能拿到；单个方法的行为通过 oracle 探测。 |
 | **准确性** | 高 —— 每条 opcode 都对应 JVM 实际观察到的 JNI 调用。 | best-effort —— 抬升器靠模式匹配，无法保持栈平衡时退化为 stub。 | 精确（它执行真实代码），但算法要你从 oracle 的输入/输出去逆 —— 它**不会**自动产出字节码。 |
 | **耗时** | 受目标本身执行时长 + agent 开销限制。 | 受 Ghidra 自动分析限制（1 MB 量级的 blob 通常需要数分钟）。 | 快 —— 无 Ghidra、无活 JVM。 |
@@ -253,7 +253,9 @@ scripts/j2c doctor       # Windows：scripts\j2c.ps1 doctor
 `lief`）、已构建的 JVM 模块与本机匹配的 native agent，以及可选工具（Ghidra、
 unicorn、zig），并为每个缺失项打印下一步命令。它只校验工具版本与产物是否存在，
 不会启动 JVM 模块或加载 agent。只有当某个必需项**缺失**时它才以非零码退出；
-`WARN`（例如 `JAVA_HOME` 未设）只是提醒，不是阻塞。
+`WARN`（例如 `JAVA_HOME` 未设）只是提醒，不是阻塞。agent 必须在文件名和 CPU 架构
+两方面都与本机匹配：在非 x86-64 主机上，`native/build.sh` 无法产出可加载的 agent，
+因此它始终被报告为 missing，动态路径不算就绪。
 
 ### 3. 恢复（默认路径 —— 动态）
 
@@ -280,10 +282,11 @@ scripts/j2c recover \
 覆盖实际执行到的路径，因此未观察到的方法可能仍是桩或只有部分方法体；请检查结果，
 难度较大的目标要预期需要人工补全（见上文的"人工过一遍"说明）。
 
-> `scripts/j2c ...` 会用 setup 安装这些包的解释器来运行 CLI（`py/.venv` 下的
-> `uv` venv，或 `pip` 兜底所用的解释器）。如果你自己激活了那个环境，等价的
-> `python3 -m j2c_dumper_cli ...`（或 `python3 -m j2c_dumper_cli.main ...`）也能用
-> —— 启动器只是帮你免于挑错解释器。
+> **只用一个解释器。** `scripts/j2c ...` 会用 setup 安装这些包的解释器来运行 CLI
+> （`py/.venv` 下的 `uv` venv，或 `pip` 兜底所用的解释器），你不必自己挑。少数
+> CLI 没有包装的用法（下面的模拟 harness、抬升器的 feature flag）也走同一个解释器，
+> 本文写作 `py/.venv/bin/python`（Windows 上为 `py\.venv\Scripts\python`）。如果
+> setup 走的是 `pip` 兜底，就换成它安装到的那个解释器。
 
 ### 兜底：模拟恢复（无需运行、无需 Ghidra）
 
@@ -292,16 +295,17 @@ scripts/j2c recover \
 也不需要 Ghidra：
 
 ```bash
-pip install unicorn
+# 把 unicorn 装进工作区解释器（pip 兜底时用 python3 -m pip install unicorn）
+(cd py && uv pip install unicorn)
 
 # 列出 native 方法（入口自动发现）
-python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 
 # dump 某个函数解密后的字符串常量（字母表、密文、提示语）
-python3 py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
+py/.venv/bin/python py/native_emulate/j2c_emu.py strings natives.bin --fn 0x<addr>
 
 # 把 native 方法当纯函数调用（oracle）
-python3 py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
+py/.venv/bin/python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
     --arg-bytes "input" --static "v=@alphabet.txt"
 ```
 
@@ -333,7 +337,7 @@ scripts/j2c merge-manifest classes.json binary.json -o manifest.json
     -postScript DumpFromManifest.java manifest.json ghidra-dump.json
 
 # 3. pseudo-C 抬升到字节码 + 重建 JAR
-python3 -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
+scripts/j2c static-reverse ghidra-dump.json --manifest manifest.json -o recovered/
 scripts/j2c rebuild --input in.jar --recovered recovered/ \
     --manifest manifest.json -o out.jar
 ```
@@ -355,11 +359,13 @@ scripts/j2c rebuild --input in.jar --recovered recovered/ \
 hint、ExceptionCheck-guard 跳过、符号表跟踪、查表解析等等）。哪个 flag
 对当前二进制误判，就把它关掉：
 
+这些 flag 没有暴露在 `scripts/j2c static-reverse` 上，因此用工作区解释器直接跑抬升器：
+
 ```bash
-python3 -m ast_matcher.cli ghidra-dump.json -o recovered/ \
+py/.venv/bin/python -m ast_matcher.cli ghidra-dump.json -o recovered/ \
     --disable use_throw_reason_invoke_hints \
     --disable skip_native_exception_guards
-python3 -m ast_matcher.cli --list-flags
+py/.venv/bin/python -m ast_matcher.cli --list-flags
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,14 +21,30 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 
 ---
 
-## ⭐ 最佳用法：用编码智能体来驱动
+## 自己动手运行
 
-**本项目的最佳用法是用您喜爱的编码智能体，加载随仓库附带的 skill
-（[`.claude/skills/j2c-deobfuscate`](.claude/skills/j2c-deobfuscate/SKILL.md)）来完成工作。**
+默认的恢复路径完全可以手动跑起来，不需要任何编码智能体：
 
-本项目提供的是对所有类似工具（凡是"把 Java 转译成 C/C++ 再通过 JNI 回调"的混淆器家族）的**通杀思路 + 工具**，但这不可避免地需要对具体情况做出一定适配（读反编译、补每个方法依赖的状态、扩展 harness、加 profile）。如今的 AI 已经可以很好地胜任这一工作。
+```bash
+git clone <本仓库> && cd c2j-native-deobfuscator
+bash scripts/setup.sh                     # 构建 JVM + Python + native agent
+python -m j2c_dumper_cli doctor           # 确认工具链就绪
+python -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+```
 
-所以，**请不要尝试手动单纯地执行现成的脚本**。在没有手工修复的情况下，本项目并不能达到惊艳的效果。把 skill 和目标交给智能体，让它把工具适配到具体的二进制上。
+详见下方的 [Quick start](#quick-start) 以及
+[10 分钟上手指南](docs/getting-started.zh-CN.md)
+（[English](docs/getting-started.md)）。
+
+**什么时候需要人工过一遍。** 本项目提供的是对整个"把 Java 转译成 C/C++
+再通过 JNI 回调"混淆器家族的**通用思路**，所以难度较大的目标仍可能需要针对
+具体方法做适配（读反编译、补每个方法依赖的状态、扩展 harness、加 profile）。
+遇到这种情况，恢复出的 `*.json` 中间产物本就是给你手工编辑的 —— 参见
+[`docs/manual-restoration.md`](docs/manual-restoration.md)。
+
+**可选：** 编码智能体很擅长做这类适配。如果你用它，可以加载随仓库附带的 skill
+（[`.claude/skills/j2c-deobfuscate`](.claude/skills/j2c-deobfuscate/SKILL.md)）
+再把目标交给它。这只是锦上添花，并非必需 —— CLI 本身即可独立运行。
 
 ---
 
@@ -201,26 +217,41 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 
 ## Quick start
 
-### 一次性构建
+前置条件：**JDK 21+**（并设置 `JAVA_HOME`）与 **Python 3.11+**。
+第一次上手？请按
+[10 分钟上手指南](docs/getting-started.zh-CN.md)（[English](docs/getting-started.md)）操作。
+
+### 1. 安装（一次性构建全部）
 
 ```bash
-# JVM 模块
-cd jvm && ./gradlew installDist
-
-# Python 工作区
-cd py && uv sync --all-packages
-
-# Native agent（仅动态路径需要）
-cd native && JDK_HOME="$JAVA_HOME" bash build.sh
-
-# 模拟路径
-cd py && .venv/Scripts/python -m pip install unicorn   # 或用你的 venv 的 pip
+# 幂等脚本：构建 JVM 模块、同步 Python 工作区，并在检测到 JDK + zig 时构建
+# native agent。可以放心重复执行。
+bash scripts/setup.sh            # Linux / macOS
+# Windows（PowerShell）：
+#   pwsh scripts/setup.ps1
 ```
 
-### 动态恢复（首选，前提是目标在你环境里能跑）
+`scripts/setup.sh` 在可用时用 [`uv`](https://docs.astral.sh/uv/) 同步 Python
+工作区，否则回退到 `pip install -e`。native agent 这一步需要 JDK 和 `zig`；
+缺任意一个时会带清晰提示跳过（只有动态路径需要它）。
+
+### 2. 检查工具链
 
 ```bash
-python -m j2c_dumper_cli.main recover \
+python -m j2c_dumper_cli doctor
+```
+
+`doctor` 会报告 Java/JDK、Python、已构建的 JVM 模块与 native agent，以及可选
+工具（Ghidra、unicorn、zig），并为每个缺失项打印下一步命令。默认路径未就绪
+时它会以非零码退出。
+
+### 3. 恢复（默认路径 —— 动态）
+
+**当目标在你环境里能跑起来时用这条。** 它把 JVMTI agent 挂到一次真实运行上，
+观察 JNI 调用流，再抬升回字节码：
+
+```bash
+python -m j2c_dumper_cli recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -235,29 +266,18 @@ python -m j2c_dumper_cli.main recover \
 5. `trace-to-bc`       抬升到 `recovered/*.json`
 6. `rebuild`           输出 loader 已剥离的最终 JAR
 
-### 静态恢复（目标跑不起来时使用 —— 需要 Ghidra）
+> `python -m j2c_dumper_cli ...` 是更友好的入口；
+> `python -m j2c_dumper_cli.main ...` 仍然可用。
+
+### 兜底：模拟恢复（无需运行、无需 Ghidra）
+
+**当目标在你环境里跑不起来时用这条** —— 例如你只有 blob，或者你需要那些只藏在
+纯 C 里的解密常量。它在 CPU 模拟器 + mock JNI 下直接执行 native 代码，不需要 JVM，
+也不需要 Ghidra：
 
 ```bash
-# 1. 解析 jar + 内省二进制（不需要 --run-cmd）
-python -m j2c_dumper_cli.main parse-jar      in.jar      -o classes.json
-python -m j2c_dumper_cli.main inspect-binary natives.bin -o binary.json
-python -m j2c_dumper_cli.main merge-manifest classes.json binary.json -o manifest.json
+pip install unicorn
 
-# 2. 用 Ghidra Headless 跑 native blob
-<GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
-    -import natives.bin \
-    -scriptPath <repo>/ghidra/scripts \
-    -postScript DumpFromManifest.java manifest.json ghidra-dump.json
-
-# 3. pseudo-C 抬升到字节码 + 重建 JAR
-python -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
-python -m j2c_dumper_cli.main rebuild --input in.jar --recovered recovered/ \
-    --manifest manifest.json -o out.jar
-```
-
-### 模拟恢复（无需 JVM、无需 Ghidra —— 针对纯 C 改写的逻辑 / 解密常量）
-
-```bash
 # 列出 native 方法（入口自动发现）
 python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 
@@ -275,7 +295,32 @@ python py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
 ### 分阶段执行
 
 每个阶段都有独立的子命令，详见
-`python -m j2c_dumper_cli.main --help`。
+`python -m j2c_dumper_cli --help`。
+
+---
+
+## 进阶：静态恢复（离线，需要 Ghidra）
+
+静态路径是**可选**的，只有在目标跑不起来**且**你需要模拟兜底不会自动产出的
+逐方法覆盖时才用得上。它需要 **Ghidra 11.x**：
+
+```bash
+# 1. 解析 jar + 内省二进制（不需要 --run-cmd）
+python -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
+python -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
+python -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
+
+# 2. 用 Ghidra Headless 跑 native blob
+<GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
+    -import natives.bin \
+    -scriptPath <repo>/ghidra/scripts \
+    -postScript DumpFromManifest.java manifest.json ghidra-dump.json
+
+# 3. pseudo-C 抬升到字节码 + 重建 JAR
+python -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
+python -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
+    --manifest manifest.json -o out.jar
+```
 
 ---
 
@@ -336,6 +381,8 @@ python -m ast_matcher.cli --list-flags
 
 ## 文档
 
+- [getting-started.zh-CN.md](docs/getting-started.zh-CN.md) — 10 分钟默认路径
+  上手、常见故障、JSON 产物在哪
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — 模块边界、管线、artifact schema、扩展点
 - [emulation-recovery.md](docs/emulation-recovery.md) — 模拟路径使用指南
   （命令参考见 [`py/native_emulate/README.md`](py/native_emulate/README.md)）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -295,7 +295,7 @@ scripts/j2c recover \
 也不需要 Ghidra：
 
 ```bash
-# 把 unicorn 装进工作区解释器（pip 兜底时用 python3 -m pip install unicorn）
+# 把 unicorn 装进工作区解释器（走 pip 兜底时，`scripts/j2c doctor` 会打印确切命令）
 (cd py && uv pip install unicorn)
 
 # 列出 native 方法（入口自动发现）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,13 +27,14 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 
 ```bash
 git clone <本仓库> && cd c2j-native-deobfuscator
-bash scripts/setup.sh                      # 构建 JVM + Python + native agent
-python3 -m j2c_dumper_cli doctor           # 确认工具链就绪
-python3 -m j2c_dumper_cli recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+bash scripts/setup.sh                      # 构建 JVM + Python（x86-64 上再构建 native agent）
+scripts/j2c doctor                         # 检查版本 + 构建产物
+scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 ```
 
-> POSIX 示例使用 `python3`（最小化系统自带、也是 `scripts/setup.sh` 选用的解释器）。
-> 在 Windows 上请改用 `python`。
+> **请通过 `scripts/j2c` 运行 CLI**（Windows 上为 `scripts\j2c.ps1`）。setup 会用
+> `uv` 把 Python 工作区装进 `py/.venv`，所以直接用*系统* `python3 -m j2c_dumper_cli`
+> 找不到这些包。该启动器会挑选真正装了这些包的解释器。
 
 详见下方的 [Quick start](#quick-start) 以及
 [10 分钟上手指南](docs/getting-started.zh-CN.md)
@@ -229,8 +230,8 @@ Linux 的 `.so`，而不是这里 JVM 加载的 Windows `.dll`。
 ### 1. 安装（一次性构建全部）
 
 ```bash
-# 幂等脚本：构建 JVM 模块、同步 Python 工作区，并在检测到 JDK + zig 时构建
-# native agent。可以放心重复执行。
+# 幂等脚本：构建 JVM 模块、同步 Python 工作区，并在 x86-64 主机上检测到 JDK + zig
+# 时构建 native agent。可以放心重复执行。
 bash scripts/setup.sh            # Linux / macOS
 # Windows（PowerShell）：
 #   pwsh scripts/setup.ps1
@@ -238,12 +239,14 @@ bash scripts/setup.sh            # Linux / macOS
 
 `scripts/setup.sh` 在可用时用 [`uv`](https://docs.astral.sh/uv/) 同步 Python
 工作区，否则回退到 `pip install -e`。native agent 这一步需要 JDK 和 `zig`；
-缺任意一个时会带清晰提示跳过（只有动态路径需要它）。
+缺任意一个时会带清晰提示跳过（只有动态路径需要它）。`native/build.sh` 面向
+x86-64，因此在 ARM（或其他 CPU）上 setup 会跳过 native agent，并且不会报告动态
+路径就绪 —— 那里请改用模拟兜底。
 
 ### 2. 检查工具链
 
 ```bash
-python3 -m j2c_dumper_cli doctor
+scripts/j2c doctor       # Windows：scripts\j2c.ps1 doctor
 ```
 
 `doctor` 会报告 Java/JDK、Python、Python 恢复阶段是否可 import（`capstone` +
@@ -258,7 +261,7 @@ unicorn、zig），并为每个缺失项打印下一步命令。它只校验工�
 观察 JNI 调用流，再抬升回字节码：
 
 ```bash
-python3 -m j2c_dumper_cli recover \
+scripts/j2c recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -277,8 +280,10 @@ python3 -m j2c_dumper_cli recover \
 覆盖实际执行到的路径，因此未观察到的方法可能仍是桩或只有部分方法体；请检查结果，
 难度较大的目标要预期需要人工补全（见上文的"人工过一遍"说明）。
 
-> `python3 -m j2c_dumper_cli ...` 是更友好的入口；
-> `python3 -m j2c_dumper_cli.main ...` 仍然可用。
+> `scripts/j2c ...` 会用 setup 安装这些包的解释器来运行 CLI（`py/.venv` 下的
+> `uv` venv，或 `pip` 兜底所用的解释器）。如果你自己激活了那个环境，等价的
+> `python3 -m j2c_dumper_cli ...`（或 `python3 -m j2c_dumper_cli.main ...`）也能用
+> —— 启动器只是帮你免于挑错解释器。
 
 ### 兜底：模拟恢复（无需运行、无需 Ghidra）
 
@@ -306,7 +311,7 @@ python3 py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
 ### 分阶段执行
 
 每个阶段都有独立的子命令，详见
-`python3 -m j2c_dumper_cli --help`。
+`scripts/j2c --help`。
 
 ---
 
@@ -317,9 +322,9 @@ python3 py/native_emulate/j2c_emu.py call natives.bin --fn 0x<addr> \
 
 ```bash
 # 1. 解析 jar + 内省二进制（不需要 --run-cmd）
-python3 -m j2c_dumper_cli parse-jar      in.jar      -o classes.json
-python3 -m j2c_dumper_cli inspect-binary natives.bin -o binary.json
-python3 -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.json
+scripts/j2c parse-jar      in.jar      -o classes.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+scripts/j2c merge-manifest classes.json binary.json -o manifest.json
 
 # 2. 用 Ghidra Headless 跑 native blob
 <GHIDRA>/support/analyzeHeadless.bat <project-dir> proj \
@@ -329,7 +334,7 @@ python3 -m j2c_dumper_cli merge-manifest classes.json binary.json -o manifest.js
 
 # 3. pseudo-C 抬升到字节码 + 重建 JAR
 python3 -m ast_matcher.cli ghidra-dump.json --manifest manifest.json -o recovered/
-python3 -m j2c_dumper_cli rebuild --input in.jar --recovered recovered/ \
+scripts/j2c rebuild --input in.jar --recovered recovered/ \
     --manifest manifest.json -o out.jar
 ```
 

--- a/docs/adding-obfuscator-profile.md
+++ b/docs/adding-obfuscator-profile.md
@@ -52,11 +52,14 @@ register_profile(Profile(
 ))
 ```
 
-放在 `PYTHONPATH` 上即可，启动时 `import` 一下：
+放在 `PYTHONPATH` 上即可，然后在启动 CLI 前 `import` 一下，让它注册进来。
+注意要用 setup 装包的那个工作区解释器（`py/.venv/bin/python`，Windows 上是
+`py\.venv\Scripts\python.exe`）——系统 `python3` 看不到这些包：
 
 ```bash
-PYTHONPATH=./my_profiles python -c "import obfuscator_x" \
-    binary-introspect introspect ./mybin.dll -o binary.json --profile obfuscator_x
+PYTHONPATH=./my_profiles py/.venv/bin/python \
+    -c "import obfuscator_x; from binary_introspect.cli import cli; cli()" \
+    introspect ./mybin.dll -o binary.json --profile obfuscator_x
 ```
 
 ## 三、深度变体：新 harvest 策略
@@ -98,11 +101,13 @@ register_profile(Profile(..., detector=my_detect))
 任何场景下都可以用 `--profile <name>` 跳过自动检测：
 
 ```bash
-binary-introspect introspect mybin.dll -o binary.json --profile obfuscator_x
-binary-introspect introspect mybin.dll -o binary.json --profile generic   # 完全不带任何变体偏好
+py/.venv/bin/python -c "from binary_introspect.cli import cli; cli()" \
+    introspect mybin.dll -o binary.json --profile obfuscator_x
+py/.venv/bin/python -c "from binary_introspect.cli import cli; cli()" \
+    introspect mybin.dll -o binary.json --profile generic   # 完全不带任何变体偏好
 ```
 
-`binary-introspect introspect --list-profiles` 列出已注册的全部 profile。
+同一条命令加上 `--list-profiles`，会列出已注册的全部 profile。
 
 ## 六、当前未参数化、需要 PR 才能扩展的部分
 

--- a/docs/emulation-recovery.md
+++ b/docs/emulation-recovery.md
@@ -80,7 +80,7 @@ workspace into — the `uv` venv at `py/.venv` (`py\.venv\Scripts\python` on
 Windows), or the interpreter the `pip` fallback used:
 
 ```bash
-(cd py && uv pip install unicorn)    # pip fallback: python3 -m pip install unicorn
+(cd py && uv pip install unicorn)    # no uv? `scripts/j2c doctor` prints the exact command
 ```
 
 Get a registrar address for j2cc-style dispatch (not needed for native-

--- a/docs/emulation-recovery.md
+++ b/docs/emulation-recovery.md
@@ -75,14 +75,18 @@ this adaptation well; running the scripts blind will not.
 
 ## Prerequisites
 
+`unicorn` goes into the same interpreter `scripts/setup.sh` installed the
+workspace into — the `uv` venv at `py/.venv` (`py\.venv\Scripts\python` on
+Windows), or the interpreter the `pip` fallback used:
+
 ```bash
-python -m pip install unicorn        # into the j2c-dumper py venv
+(cd py && uv pip install unicorn)    # pip fallback: python3 -m pip install unicorn
 ```
 
 Get a registrar address for j2cc-style dispatch (not needed for native-
 obfuscator `Java_*` / `JNI_OnLoad`):
 
 ```bash
-python -m j2c_dumper_cli.main inspect-binary natives.bin -o binary.json
-python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,139 @@
+[English](getting-started.md) | [中文](getting-started.zh-CN.md)
+
+# Getting started (10 minutes)
+
+This is the shortest path from a fresh checkout to a recovered jar, using the
+**default (dynamic) path** — no Ghidra and no coding agent required.
+
+The dynamic path works when you can *launch* the obfuscated jar in your
+environment. If you can't run it, jump to
+[When you can't run the jar](#when-you-cant-run-the-jar).
+
+---
+
+## 0. Prerequisites
+
+- **JDK 21+** with `JAVA_HOME` pointing at it (`java -version` should print 21+).
+- **Python 3.11+**.
+- For the native agent build only: **[zig](https://ziglang.org/) 0.16.x**.
+  Optional; skip it and use the emulation fallback if you can't install it.
+
+Everything else (`uv`, ASM, capstone, …) is pulled in by the setup script.
+
+---
+
+## 1. Install (build everything) — ~3–5 min
+
+```bash
+git clone <this repo> && cd c2j-native-deobfuscator
+bash scripts/setup.sh            # Linux / macOS
+# Windows (PowerShell):  pwsh scripts/setup.ps1
+```
+
+`scripts/setup.sh` is idempotent (safe to re-run). It:
+
+1. builds the JVM modules (`jvm/*/build/install/...`),
+2. syncs the Python workspace (`uv sync`, or `pip install -e` as a fallback),
+3. builds the native JVMTI agent when a JDK **and** `zig` are present — otherwise
+   it prints a clear note and continues (only the dynamic path needs it).
+
+## 2. Check the toolchain — ~10 s
+
+```bash
+python -m j2c_dumper_cli doctor
+```
+
+It prints a table and, for anything missing, the exact next command. Example of
+a not-yet-ready machine:
+
+```
+JVM modules (installDist)   MISSING   not built: jar-parser, ...
+Native JVMTI agent          MISSING   no j2c_agent.(so|dll|dylib) under native/build/lib
+...
+Not ready. Missing: ... Run scripts/setup.sh (or scripts/setup.ps1) to fix.
+```
+
+`doctor` exits non-zero until the default path is ready, so you can gate a
+script on it. The optional tools (Ghidra, unicorn, zig) never block.
+
+## 3. Recover — ~1–2 min
+
+```bash
+python -m j2c_dumper_cli recover \
+    path/to/obfuscated.jar \
+    -o path/to/clean.jar \
+    --run-cmd "java -jar path/to/obfuscated.jar"
+```
+
+The `--run-cmd` is a command that actually *runs* the obfuscated jar so the
+JVMTI agent can observe it. Exercise the classes you care about (a CLI that just
+prints help won't trace the interesting code paths).
+
+When it finishes you get `path/to/clean.jar` whose native methods now have real
+bytecode bodies and whose loader / native-blob entries are stripped.
+
+---
+
+## Where the JSON artifacts appear
+
+`recover` writes its intermediates to a working directory. By default that is a
+fresh temp dir printed on the first line (`workdir: /tmp/j2c-XXXX`). Pass
+`--workdir ./work` to choose your own. Inside it:
+
+| File | Produced by | What it is |
+|---|---|---|
+| `classes.json`   | `parse-jar`      | class skeletons + native-method registry |
+| `binary.json`    | `inspect-binary` | string pool + hidden classes from the blob |
+| `manifest.json`  | `merge-manifest` | the two merged; includes the `cacheTable` |
+| `trace.jsonl`    | `dynamic-trace`  | one JSON line per observed JNI call |
+| `recovered/*.json` | `trace-to-bc`  | lifted bytecode, one file per native method |
+| your `-o` jar    | `rebuild`        | the final loader-stripped output |
+
+The `recovered/*.json` files are the artifacts you hand-edit if a hard target
+needs a human pass — see [`manual-restoration.md`](manual-restoration.md).
+
+---
+
+## Common failures
+
+**`recover cannot start: required build artifacts are missing`**
+The JVM modules or native agent aren't built. Run `scripts/setup.sh` (or
+`scripts/setup.ps1`) and then `python -m j2c_dumper_cli doctor`.
+
+**`doctor` says `Java / JDK 21+  WARN` — JAVA_HOME is not set**
+Java is new enough but `JAVA_HOME` is unset; the native agent build needs it.
+Set `JAVA_HOME` to your JDK directory and re-run `scripts/setup.sh`.
+
+**`doctor` says `Native JVMTI agent  MISSING` and setup skipped it**
+`zig` (or the JDK headers) wasn't found. Install
+[zig](https://ziglang.org/) 0.16.x (or set `ZIG` to its path), set `JAVA_HOME`,
+then `bash scripts/setup.sh --force`. If you can't install `zig`, use the
+emulation fallback below.
+
+**The Gradle build can't find a matching Java toolchain**
+Install a JDK 21+ and set `JAVA_HOME`, then re-run. `doctor` shows which Java it
+found.
+
+**`recover` ran but `trace.jsonl` has no `enter` events**
+Your `--run-cmd` didn't reach the obfuscated classes. Use a command that
+actually exercises them; only executed branches are recovered on the dynamic
+path.
+
+---
+
+## When you can't run the jar
+
+Use the **emulation fallback** — no JVM and no Ghidra. It runs the native code
+under a CPU emulator with a mock JNI, so it can list the native methods, dump
+decrypted constants, and call methods as pure-function oracles:
+
+```bash
+pip install unicorn
+python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+```
+
+Full walkthrough: [`emulation-recovery.md`](emulation-recovery.md).
+
+The **static path** (Ghidra) is an *advanced, optional* route for offline
+per-method coverage; see the "Advanced" section of the
+[README](../README.md#advanced-static-recovery-offline-needs-ghidra).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,11 @@ Everything else (`uv`, ASM, `capstone`, `lief`, …) is pulled in by the setup
 script. The default recover path imports `capstone`, so it is a required
 dependency of `binary-introspect`, not optional.
 
-> The commands below use `python3` (the interpreter a minimal POSIX system
-> ships and that `scripts/setup.sh` selects). On Windows, use `python`.
+> **Run the CLI through `scripts/j2c`** (`scripts\j2c.ps1` on Windows). Setup
+> installs the Python workspace into `py/.venv` via `uv`, so a bare
+> `python3 -m j2c_dumper_cli` on the *system* interpreter would not find the
+> packages. The launcher runs the interpreter the packages are actually in (the
+> `uv` venv, or the interpreter the `pip` fallback used).
 
 ---
 
@@ -43,13 +46,16 @@ bash scripts/setup.sh            # Linux / macOS
 
 1. builds the JVM modules (`jvm/*/build/install/...`),
 2. syncs the Python workspace (`uv sync`, or `pip install -e` as a fallback),
-3. builds the native JVMTI agent when a JDK **and** `zig` are present — otherwise
-   it prints a clear note and continues (only the dynamic path needs it).
+3. builds the native JVMTI agent when a JDK **and** `zig` are present **and the
+   host is x86-64** — otherwise it prints a clear note and continues (only the
+   dynamic path needs it). `native/build.sh` targets x86-64; on ARM (or any
+   other CPU) setup skips the native agent and does *not* report the dynamic
+   path as ready.
 
 ## 2. Check the toolchain — ~10 s
 
 ```bash
-python3 -m j2c_dumper_cli doctor
+scripts/j2c doctor       # Windows:  scripts\j2c.ps1 doctor
 ```
 
 It prints a table and, for anything missing, the exact next command. Example of
@@ -69,12 +75,13 @@ on it. A `WARN` (for example, Java is new enough but `JAVA_HOME` is unset) is a
 caveat, not a failure, and does not flip the ready bit. The optional tools
 (Ghidra, unicorn, zig) never block. On this host `doctor` only accepts the agent
 name it can actually load (`j2c_agent.so` on Linux, `.dylib` on macOS, `.dll` on
-Windows); a leftover build for another OS is reported as missing.
+Windows); a leftover build for another OS, or one built for a different CPU
+architecture, is reported as missing.
 
 ## 3. Recover — ~1–2 min
 
 ```bash
-python3 -m j2c_dumper_cli recover \
+scripts/j2c recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -117,7 +124,7 @@ needs a human pass — see [`manual-restoration.md`](manual-restoration.md).
 
 **`recover cannot start: required build artifacts are missing`**
 The JVM modules or native agent aren't built. Run `scripts/setup.sh` (or
-`scripts/setup.ps1`) and then `python3 -m j2c_dumper_cli doctor`.
+`scripts/setup.ps1`) and then `scripts/j2c doctor`.
 
 **`doctor` says `Java / JDK 17+  WARN` — JAVA_HOME is not set**
 Java is new enough but `JAVA_HOME` is unset; the native agent build needs it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,7 +163,7 @@ Install `unicorn` into the interpreter setup used, and run the harness with it
 (the launcher only wraps the CLI subcommands):
 
 ```bash
-(cd py && uv pip install unicorn)    # pip fallback: python3 -m pip install unicorn
+(cd py && uv pip install unicorn)    # no uv? `scripts/j2c doctor` prints the exact command
 py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,8 +75,12 @@ on it. A `WARN` (for example, Java is new enough but `JAVA_HOME` is unset) is a
 caveat, not a failure, and does not flip the ready bit. The optional tools
 (Ghidra, unicorn, zig) never block. On this host `doctor` only accepts the agent
 name it can actually load (`j2c_agent.so` on Linux, `.dylib` on macOS, `.dll` on
-Windows); a leftover build for another OS, or one built for a different CPU
-architecture, is reported as missing.
+Windows) *and* a file whose header says it was built for this CPU; a leftover
+build for another OS, a different architecture, or an unreadable file is
+reported as missing. Because `native/build.sh` only targets x86-64, a non-x86-64
+host (ARM, for example) always reports the agent as missing — the dynamic path
+is unavailable there, whatever sits in `native/build/lib`. Use the emulation
+fallback or the static path instead; neither needs the agent.
 
 ## 3. Recover — ~1–2 min
 
@@ -155,9 +159,12 @@ Use the **emulation fallback** — no JVM and no Ghidra. It runs the native code
 under a CPU emulator with a mock JNI, so it can list the native methods, dump
 decrypted constants, and call methods as pure-function oracles:
 
+Install `unicorn` into the interpreter setup used, and run the harness with it
+(the launcher only wraps the CLI subcommands):
+
 ```bash
-pip install unicorn
-python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+(cd py && uv pip install unicorn)    # pip fallback: python3 -m pip install unicorn
+py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```
 
 Full walkthrough: [`emulation-recovery.md`](emulation-recovery.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,12 +13,21 @@ environment. If you can't run it, jump to
 
 ## 0. Prerequisites
 
-- **JDK 21+** with `JAVA_HOME` pointing at it (`java -version` should print 21+).
+- **JDK 17+** with `JAVA_HOME` pointing at it (`java -version` should print 17+).
 - **Python 3.11+**.
 - For the native agent build only: **[zig](https://ziglang.org/) 0.16.x**.
   Optional; skip it and use the emulation fallback if you can't install it.
+- On **Windows**, the native agent build additionally needs **Git Bash** (from
+  [Git for Windows](https://git-scm.com/download/win)) so `native/build.sh` can
+  run and produce the Windows DLL. WSL is *not* an equivalent: it builds a Linux
+  `.so`, not the Windows `.dll` the JVM loads here.
 
-Everything else (`uv`, ASM, capstone, …) is pulled in by the setup script.
+Everything else (`uv`, ASM, `capstone`, `lief`, …) is pulled in by the setup
+script. The default recover path imports `capstone`, so it is a required
+dependency of `binary-introspect`, not optional.
+
+> The commands below use `python3` (the interpreter a minimal POSIX system
+> ships and that `scripts/setup.sh` selects). On Windows, use `python`.
 
 ---
 
@@ -40,7 +49,7 @@ bash scripts/setup.sh            # Linux / macOS
 ## 2. Check the toolchain — ~10 s
 
 ```bash
-python -m j2c_dumper_cli doctor
+python3 -m j2c_dumper_cli doctor
 ```
 
 It prints a table and, for anything missing, the exact next command. Example of
@@ -48,18 +57,24 @@ a not-yet-ready machine:
 
 ```
 JVM modules (installDist)   MISSING   not built: jar-parser, ...
-Native JVMTI agent          MISSING   no j2c_agent.(so|dll|dylib) under native/build/lib
+Native JVMTI agent          MISSING   no j2c_agent.so under native/build/lib
 ...
 Not ready. Missing: ... Run scripts/setup.sh (or scripts/setup.ps1) to fix.
 ```
 
-`doctor` exits non-zero until the default path is ready, so you can gate a
-script on it. The optional tools (Ghidra, unicorn, zig) never block.
+`doctor` checks tool versions and that the build artifacts the default path
+needs are present (it does not launch the JVM modules or load the agent). It
+exits non-zero only when a required piece is *missing*, so you can gate a script
+on it. A `WARN` (for example, Java is new enough but `JAVA_HOME` is unset) is a
+caveat, not a failure, and does not flip the ready bit. The optional tools
+(Ghidra, unicorn, zig) never block. On this host `doctor` only accepts the agent
+name it can actually load (`j2c_agent.so` on Linux, `.dylib` on macOS, `.dll` on
+Windows); a leftover build for another OS is reported as missing.
 
 ## 3. Recover — ~1–2 min
 
 ```bash
-python -m j2c_dumper_cli recover \
+python3 -m j2c_dumper_cli recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -69,8 +84,12 @@ The `--run-cmd` is a command that actually *runs* the obfuscated jar so the
 JVMTI agent can observe it. Exercise the classes you care about (a CLI that just
 prints help won't trace the interesting code paths).
 
-When it finishes you get `path/to/clean.jar` whose native methods now have real
-bytecode bodies and whose loader / native-blob entries are stripped.
+When it finishes you get `path/to/clean.jar` whose native-method stubs are
+replaced with *best-effort recovered bodies for the behavior that was observed*,
+and whose loader / native-blob entries are stripped. Dynamic tracing only covers
+the paths your `--run-cmd` actually executed; unobserved methods may keep a stub
+or a partial body, so inspect the output and expect some manual completion on
+hard targets.
 
 ---
 
@@ -98,20 +117,22 @@ needs a human pass — see [`manual-restoration.md`](manual-restoration.md).
 
 **`recover cannot start: required build artifacts are missing`**
 The JVM modules or native agent aren't built. Run `scripts/setup.sh` (or
-`scripts/setup.ps1`) and then `python -m j2c_dumper_cli doctor`.
+`scripts/setup.ps1`) and then `python3 -m j2c_dumper_cli doctor`.
 
-**`doctor` says `Java / JDK 21+  WARN` — JAVA_HOME is not set**
+**`doctor` says `Java / JDK 17+  WARN` — JAVA_HOME is not set**
 Java is new enough but `JAVA_HOME` is unset; the native agent build needs it.
-Set `JAVA_HOME` to your JDK directory and re-run `scripts/setup.sh`.
+This is a warning, not a blocker: if the agent is already built you can still
+run the dynamic path. Set `JAVA_HOME` to your JDK directory and re-run
+`scripts/setup.sh` when you next need to build the agent.
 
 **`doctor` says `Native JVMTI agent  MISSING` and setup skipped it**
-`zig` (or the JDK headers) wasn't found. Install
-[zig](https://ziglang.org/) 0.16.x (or set `ZIG` to its path), set `JAVA_HOME`,
-then `bash scripts/setup.sh --force`. If you can't install `zig`, use the
-emulation fallback below.
+`zig` (or the JDK headers) wasn't found — or a leftover agent for a different OS
+is present. Install [zig](https://ziglang.org/) 0.16.x (or set `ZIG` to its
+path), set `JAVA_HOME`, then `bash scripts/setup.sh --force`. If you can't
+install `zig`, use the emulation fallback below.
 
 **The Gradle build can't find a matching Java toolchain**
-Install a JDK 21+ and set `JAVA_HOME`, then re-run. `doctor` shows which Java it
+Install a JDK 17+ and set `JAVA_HOME`, then re-run. `doctor` shows which Java it
 found.
 
 **`recover` ran but `trace.jsonl` has no `enter` events**
@@ -129,7 +150,7 @@ decrypted constants, and call methods as pure-function oracles:
 
 ```bash
 pip install unicorn
-python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```
 
 Full walkthrough: [`emulation-recovery.md`](emulation-recovery.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,9 +155,27 @@ path.
 
 ## When you can't run the jar
 
-Use the **emulation fallback** — no JVM and no Ghidra. It runs the native code
-under a CPU emulator with a mock JNI, so it can list the native methods, dump
-decrypted constants, and call methods as pure-function oracles:
+Start with the generic, Ghidra-free discovery pipeline. It combines the JAR's
+native declarations with standard JNI entry-point evidence: direct `Java_*`
+exports and dynamic `RegisterNatives` registrations.
+
+```bash
+scripts/j2c parse-jar      in.jar      -o classes.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+scripts/j2c merge-manifest classes.json binary.json -o manifest.json
+```
+
+These three steps do **not** require a live run or Ghidra. They produce the
+method-discovery manifest, not recovered method bodies. The generic discovery
+implementation lives in
+[`py/binary_introspect`](../py/binary_introspect); broader generic-first
+coverage is being completed on
+[PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4).
+
+For executable behavior and C-only constants, use the **emulation fallback**.
+It also needs no JVM or Ghidra: it runs the native code under a CPU emulator
+with a mock JNI, so it can list the native methods, dump decrypted constants,
+and call methods as pure-function oracles.
 
 Install `unicorn` into the interpreter setup used, and run the harness with it
 (the launcher only wraps the CLI subcommands):
@@ -169,6 +187,6 @@ py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-js
 
 Full walkthrough: [`emulation-recovery.md`](emulation-recovery.md).
 
-The **static path** (Ghidra) is an *advanced, optional* route for offline
-per-method coverage; see the "Advanced" section of the
-[README](../README.md#advanced-static-recovery-offline-needs-ghidra).
+Ghidra Headless is an **optional later step** when the JAR cannot run and you
+want pseudo-C to lift into static method bodies. See the "Advanced" section of
+the [README](../README.md#advanced-static-recovery-offline-needs-ghidra).

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -138,9 +138,23 @@ Java 版本够新，但 `JAVA_HOME` 没设；native agent 构建需要它。这�
 
 ## 目标跑不起来时怎么办
 
-改用**模拟兜底** —— 无需 JVM、无需 Ghidra。它在 CPU 模拟器 + mock JNI 下直接执行
-native 代码，因此能列出 native 方法、dump 解密后的常量，并把方法当纯函数 oracle
-来调用：
+先运行通用、无需 Ghidra 的发现管线。它把 JAR 中的 native 声明与 JNI 标准入口证据
+合并起来：直接导出的 `Java_*` 符号和 `RegisterNatives` 动态注册。
+
+```bash
+scripts/j2c parse-jar      in.jar      -o classes.json
+scripts/j2c inspect-binary natives.bin -o binary.json
+scripts/j2c merge-manifest classes.json binary.json -o manifest.json
+```
+
+这三步既不需要真实运行，也不需要 Ghidra；它们产出的是方法发现 manifest，而不是
+恢复后的方法体。通用发现实现位于
+[`py/binary_introspect`](../py/binary_introspect)；更完整的 generic-first 覆盖正在
+[PR #4](https://github.com/gaoyu06/c2j-native-deobfuscator/pull/4) 中完成。
+
+如果要获得可执行行为和纯 C 常量，再使用**模拟兜底**。它同样无需 JVM、无需 Ghidra：
+在 CPU 模拟器 + mock JNI 下直接执行 native 代码，因此能列出 native 方法、dump
+解密后的常量，并把方法当纯函数 oracle 来调用。
 
 把 `unicorn` 装进 setup 所用的那个解释器，并用它来跑 harness（启动器只包装 CLI 子命令）：
 
@@ -151,5 +165,6 @@ py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-js
 
 完整步骤见 [`emulation-recovery.md`](emulation-recovery.md)。
 
-**静态路径**（Ghidra）是用于离线逐方法覆盖的**进阶、可选**路线；见
+当 JAR 无法运行、而你又希望得到可抬升为静态方法体的 pseudo-C 时，Ghidra Headless
+才是一个**可选的后续步骤**；见
 [README](../README.zh-CN.md) 里的"进阶：静态恢复"一节。

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -12,12 +12,20 @@
 
 ## 0. 前置条件
 
-- **JDK 21+**，并把 `JAVA_HOME` 指向它（`java -version` 应显示 21 及以上）。
+- **JDK 17+**，并把 `JAVA_HOME` 指向它（`java -version` 应显示 17 及以上）。
 - **Python 3.11+**。
 - 仅构建 native agent 时需要：**[zig](https://ziglang.org/) 0.16.x**。
   可选；装不上就跳过它，改用模拟兜底。
+- 在 **Windows** 上构建 native agent 还需要 **Git Bash**（随
+  [Git for Windows](https://git-scm.com/download/win) 提供），这样才能运行
+  `native/build.sh` 并产出 Windows DLL。WSL **不等价**：它会构建 Linux 的
+  `.so`，而不是这里 JVM 加载的 Windows `.dll`。
 
-其余依赖（`uv`、ASM、capstone……）都由 setup 脚本自动拉取。
+其余依赖（`uv`、ASM、`capstone`、`lief`……）都由 setup 脚本自动拉取。默认恢复
+路径会 import `capstone`，因此它是 `binary-introspect` 的必需依赖，并非可选。
+
+> 下面的命令使用 `python3`（最小化 POSIX 系统自带、且 `scripts/setup.sh` 选用的
+> 解释器）。在 Windows 上请改用 `python`。
 
 ---
 
@@ -39,25 +47,29 @@ bash scripts/setup.sh            # Linux / macOS
 ## 2. 检查工具链 —— 约 10 秒
 
 ```bash
-python -m j2c_dumper_cli doctor
+python3 -m j2c_dumper_cli doctor
 ```
 
 它会打印一张表，并为每个缺失项给出确切的下一步命令。一台尚未就绪的机器示例：
 
 ```
 JVM modules (installDist)   MISSING   not built: jar-parser, ...
-Native JVMTI agent          MISSING   no j2c_agent.(so|dll|dylib) under native/build/lib
+Native JVMTI agent          MISSING   no j2c_agent.so under native/build/lib
 ...
 Not ready. Missing: ... Run scripts/setup.sh (or scripts/setup.ps1) to fix.
 ```
 
-默认路径未就绪时 `doctor` 会以非零码退出，因此可以用它给脚本做前置门槛。可选
-工具（Ghidra、unicorn、zig）永远不会导致阻塞。
+`doctor` 检查工具版本，以及默认路径所需的构建产物是否存在（它不会启动 JVM 模块，
+也不会加载 agent）。只有当某个必需项**缺失**时它才以非零码退出，因此可以用它给
+脚本做前置门槛。`WARN`（例如 Java 版本够新但 `JAVA_HOME` 未设）只是提醒，不算失败，
+也不会翻转就绪标志。可选工具（Ghidra、unicorn、zig）永远不会导致阻塞。在本机上
+`doctor` 只接受它真正能加载的 agent 文件名（Linux 上是 `j2c_agent.so`，macOS 上是
+`.dylib`，Windows 上是 `.dll`）；为其他操作系统遗留的构建会被报告为 missing。
 
 ## 3. 恢复 —— 约 1–2 分钟
 
 ```bash
-python -m j2c_dumper_cli recover \
+python3 -m j2c_dumper_cli recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -66,8 +78,10 @@ python -m j2c_dumper_cli recover \
 `--run-cmd` 是一条能真正**运行**该混淆 jar 的命令，好让 JVMTI agent 观察它。
 记得触达你关心的类（一个只打印 help 的 CLI 不会 trace 到有意思的代码路径）。
 
-跑完你会得到 `path/to/clean.jar`：原先的 native 方法现在拥有真实字节码方法体，
-loader / native blob 资源条目也被剥离。
+跑完你会得到 `path/to/clean.jar`：原先的 native 方法桩会被替换为**针对已观察到的
+行为、尽力恢复出的方法体**，loader / native blob 资源条目也被剥离。动态 trace 只
+覆盖 `--run-cmd` 实际执行到的路径；未观察到的方法可能仍是桩或只有部分方法体，因此
+请检查输出，难度较大的目标要预期需要人工补全。
 
 ---
 
@@ -94,19 +108,20 @@ loader / native blob 资源条目也被剥离。
 
 **`recover cannot start: required build artifacts are missing`**
 JVM 模块或 native agent 没构建。先跑 `scripts/setup.sh`（或 `scripts/setup.ps1`），
-再 `python -m j2c_dumper_cli doctor`。
+再 `python3 -m j2c_dumper_cli doctor`。
 
-**`doctor` 显示 `Java / JDK 21+  WARN` —— JAVA_HOME 未设置**
-Java 版本够新，但 `JAVA_HOME` 没设；native agent 构建需要它。把 `JAVA_HOME`
-指向你的 JDK 目录后重跑 `scripts/setup.sh`。
+**`doctor` 显示 `Java / JDK 17+  WARN` —— JAVA_HOME 未设置**
+Java 版本够新，但 `JAVA_HOME` 没设；native agent 构建需要它。这是提醒，不是阻塞：
+如果 agent 已经构建好，动态路径仍可运行。等下次需要构建 agent 时，把 `JAVA_HOME`
+指向你的 JDK 目录再重跑 `scripts/setup.sh`。
 
 **`doctor` 显示 `Native JVMTI agent  MISSING` 且 setup 跳过了它**
-没找到 `zig`（或 JDK 头文件）。安装 [zig](https://ziglang.org/) 0.16.x（或把 `ZIG`
-设为它的路径）、设置 `JAVA_HOME`，再 `bash scripts/setup.sh --force`。装不了 `zig`
-就用下面的模拟兜底。
+没找到 `zig`（或 JDK 头文件）—— 或者存在的是为其他操作系统遗留的 agent。安装
+[zig](https://ziglang.org/) 0.16.x（或把 `ZIG` 设为它的路径）、设置 `JAVA_HOME`，
+再 `bash scripts/setup.sh --force`。装不了 `zig` 就用下面的模拟兜底。
 
 **Gradle 找不到匹配的 Java toolchain**
-安装 JDK 21+ 并设置 `JAVA_HOME` 后重跑。`doctor` 会显示它找到的是哪个 Java。
+安装 JDK 17+ 并设置 `JAVA_HOME` 后重跑。`doctor` 会显示它找到的是哪个 Java。
 
 **`recover` 跑完了，但 `trace.jsonl` 里没有 `enter` 事件**
 你的 `--run-cmd` 没触达混淆类。换一条能真正运行到它们的命令；动态路径只能恢复
@@ -122,7 +137,7 @@ native 代码，因此能列出 native 方法、dump 解密后的常量，并把
 
 ```bash
 pip install unicorn
-python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```
 
 完整步骤见 [`emulation-recovery.md`](emulation-recovery.md)。

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -24,8 +24,10 @@
 其余依赖（`uv`、ASM、`capstone`、`lief`……）都由 setup 脚本自动拉取。默认恢复
 路径会 import `capstone`，因此它是 `binary-introspect` 的必需依赖，并非可选。
 
-> 下面的命令使用 `python3`（最小化 POSIX 系统自带、且 `scripts/setup.sh` 选用的
-> 解释器）。在 Windows 上请改用 `python`。
+> **请通过 `scripts/j2c` 运行 CLI**（Windows 上为 `scripts\j2c.ps1`）。setup 会用
+> `uv` 把 Python 工作区装进 `py/.venv`，所以直接用*系统* `python3 -m j2c_dumper_cli`
+> 是找不到这些包的。该启动器会运行真正装了这些包的解释器（`uv` 的 venv，或 `pip`
+> 兜底所用的解释器）。
 
 ---
 
@@ -41,13 +43,14 @@ bash scripts/setup.sh            # Linux / macOS
 
 1. 构建 JVM 模块（`jvm/*/build/install/...`）；
 2. 同步 Python 工作区（`uv sync`，否则回退到 `pip install -e`）；
-3. 当 JDK **且** `zig` 都存在时构建 native JVMTI agent —— 否则打印清晰提示并
-   继续（只有动态路径需要它）。
+3. 当 JDK **且** `zig` 都存在、**且主机是 x86-64** 时构建 native JVMTI agent ——
+   否则打印清晰提示并继续（只有动态路径需要它）。`native/build.sh` 面向 x86-64；
+   在 ARM（或其他 CPU）上 setup 会跳过 native agent，并且*不会*报告动态路径就绪。
 
 ## 2. 检查工具链 —— 约 10 秒
 
 ```bash
-python3 -m j2c_dumper_cli doctor
+scripts/j2c doctor       # Windows：scripts\j2c.ps1 doctor
 ```
 
 它会打印一张表，并为每个缺失项给出确切的下一步命令。一台尚未就绪的机器示例：
@@ -64,12 +67,13 @@ Not ready. Missing: ... Run scripts/setup.sh (or scripts/setup.ps1) to fix.
 脚本做前置门槛。`WARN`（例如 Java 版本够新但 `JAVA_HOME` 未设）只是提醒，不算失败，
 也不会翻转就绪标志。可选工具（Ghidra、unicorn、zig）永远不会导致阻塞。在本机上
 `doctor` 只接受它真正能加载的 agent 文件名（Linux 上是 `j2c_agent.so`，macOS 上是
-`.dylib`，Windows 上是 `.dll`）；为其他操作系统遗留的构建会被报告为 missing。
+`.dylib`，Windows 上是 `.dll`）；为其他操作系统遗留、或为其他 CPU 架构构建的产物
+都会被报告为 missing。
 
 ## 3. 恢复 —— 约 1–2 分钟
 
 ```bash
-python3 -m j2c_dumper_cli recover \
+scripts/j2c recover \
     path/to/obfuscated.jar \
     -o path/to/clean.jar \
     --run-cmd "java -jar path/to/obfuscated.jar"
@@ -108,7 +112,7 @@ python3 -m j2c_dumper_cli recover \
 
 **`recover cannot start: required build artifacts are missing`**
 JVM 模块或 native agent 没构建。先跑 `scripts/setup.sh`（或 `scripts/setup.ps1`），
-再 `python3 -m j2c_dumper_cli doctor`。
+再 `scripts/j2c doctor`。
 
 **`doctor` 显示 `Java / JDK 17+  WARN` —— JAVA_HOME 未设置**
 Java 版本够新，但 `JAVA_HOME` 没设；native agent 构建需要它。这是提醒，不是阻塞：

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -1,0 +1,131 @@
+[English](getting-started.md) | [中文](getting-started.zh-CN.md)
+
+# 10 分钟上手
+
+这是从全新 clone 到产出恢复后 jar 的最短路径，走的是**默认（动态）路径** ——
+不需要 Ghidra，也不需要编码智能体。
+
+动态路径的前提是你能在自己的环境里**跑起来**这个混淆 jar。如果跑不起来，请直接
+看[目标跑不起来时怎么办](#目标跑不起来时怎么办)。
+
+---
+
+## 0. 前置条件
+
+- **JDK 21+**，并把 `JAVA_HOME` 指向它（`java -version` 应显示 21 及以上）。
+- **Python 3.11+**。
+- 仅构建 native agent 时需要：**[zig](https://ziglang.org/) 0.16.x**。
+  可选；装不上就跳过它，改用模拟兜底。
+
+其余依赖（`uv`、ASM、capstone……）都由 setup 脚本自动拉取。
+
+---
+
+## 1. 安装（一次性构建全部）—— 约 3–5 分钟
+
+```bash
+git clone <本仓库> && cd c2j-native-deobfuscator
+bash scripts/setup.sh            # Linux / macOS
+# Windows（PowerShell）：pwsh scripts/setup.ps1
+```
+
+`scripts/setup.sh` 是幂等的（可以放心重复执行）。它会：
+
+1. 构建 JVM 模块（`jvm/*/build/install/...`）；
+2. 同步 Python 工作区（`uv sync`，否则回退到 `pip install -e`）；
+3. 当 JDK **且** `zig` 都存在时构建 native JVMTI agent —— 否则打印清晰提示并
+   继续（只有动态路径需要它）。
+
+## 2. 检查工具链 —— 约 10 秒
+
+```bash
+python -m j2c_dumper_cli doctor
+```
+
+它会打印一张表，并为每个缺失项给出确切的下一步命令。一台尚未就绪的机器示例：
+
+```
+JVM modules (installDist)   MISSING   not built: jar-parser, ...
+Native JVMTI agent          MISSING   no j2c_agent.(so|dll|dylib) under native/build/lib
+...
+Not ready. Missing: ... Run scripts/setup.sh (or scripts/setup.ps1) to fix.
+```
+
+默认路径未就绪时 `doctor` 会以非零码退出，因此可以用它给脚本做前置门槛。可选
+工具（Ghidra、unicorn、zig）永远不会导致阻塞。
+
+## 3. 恢复 —— 约 1–2 分钟
+
+```bash
+python -m j2c_dumper_cli recover \
+    path/to/obfuscated.jar \
+    -o path/to/clean.jar \
+    --run-cmd "java -jar path/to/obfuscated.jar"
+```
+
+`--run-cmd` 是一条能真正**运行**该混淆 jar 的命令，好让 JVMTI agent 观察它。
+记得触达你关心的类（一个只打印 help 的 CLI 不会 trace 到有意思的代码路径）。
+
+跑完你会得到 `path/to/clean.jar`：原先的 native 方法现在拥有真实字节码方法体，
+loader / native blob 资源条目也被剥离。
+
+---
+
+## JSON 中间产物在哪里
+
+`recover` 会把中间产物写到一个工作目录。默认是首行打印的一个新临时目录
+（`workdir: /tmp/j2c-XXXX`）。用 `--workdir ./work` 可以自己指定。目录里包含：
+
+| 文件 | 由谁产出 | 内容 |
+|---|---|---|
+| `classes.json`   | `parse-jar`      | 类骨架 + native 方法注册表 |
+| `binary.json`    | `inspect-binary` | 来自 blob 的字符串池 + 隐藏类 |
+| `manifest.json`  | `merge-manifest` | 前两者合并，含 `cacheTable` |
+| `trace.jsonl`    | `dynamic-trace`  | 每条观察到的 JNI 调用一行 JSON |
+| `recovered/*.json` | `trace-to-bc`  | 抬升后的字节码，每个 native 方法一个文件 |
+| 你的 `-o` jar    | `rebuild`        | 最终 loader 已剥离的输出 |
+
+`recovered/*.json` 就是当难度较大的目标需要人工过一遍时，你要手工编辑的产物 ——
+见 [`manual-restoration.md`](manual-restoration.md)。
+
+---
+
+## 常见故障
+
+**`recover cannot start: required build artifacts are missing`**
+JVM 模块或 native agent 没构建。先跑 `scripts/setup.sh`（或 `scripts/setup.ps1`），
+再 `python -m j2c_dumper_cli doctor`。
+
+**`doctor` 显示 `Java / JDK 21+  WARN` —— JAVA_HOME 未设置**
+Java 版本够新，但 `JAVA_HOME` 没设；native agent 构建需要它。把 `JAVA_HOME`
+指向你的 JDK 目录后重跑 `scripts/setup.sh`。
+
+**`doctor` 显示 `Native JVMTI agent  MISSING` 且 setup 跳过了它**
+没找到 `zig`（或 JDK 头文件）。安装 [zig](https://ziglang.org/) 0.16.x（或把 `ZIG`
+设为它的路径）、设置 `JAVA_HOME`，再 `bash scripts/setup.sh --force`。装不了 `zig`
+就用下面的模拟兜底。
+
+**Gradle 找不到匹配的 Java toolchain**
+安装 JDK 21+ 并设置 `JAVA_HOME` 后重跑。`doctor` 会显示它找到的是哪个 Java。
+
+**`recover` 跑完了，但 `trace.jsonl` 里没有 `enter` 事件**
+你的 `--run-cmd` 没触达混淆类。换一条能真正运行到它们的命令；动态路径只能恢复
+实际执行到的分支。
+
+---
+
+## 目标跑不起来时怎么办
+
+改用**模拟兜底** —— 无需 JVM、无需 Ghidra。它在 CPU 模拟器 + mock JNI 下直接执行
+native 代码，因此能列出 native 方法、dump 解密后的常量，并把方法当纯函数 oracle
+来调用：
+
+```bash
+pip install unicorn
+python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+```
+
+完整步骤见 [`emulation-recovery.md`](emulation-recovery.md)。
+
+**静态路径**（Ghidra）是用于离线逐方法覆盖的**进阶、可选**路线；见
+[README](../README.zh-CN.md) 里的"进阶：静态恢复"一节。

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -67,8 +67,11 @@ Not ready. Missing: ... Run scripts/setup.sh (or scripts/setup.ps1) to fix.
 脚本做前置门槛。`WARN`（例如 Java 版本够新但 `JAVA_HOME` 未设）只是提醒，不算失败，
 也不会翻转就绪标志。可选工具（Ghidra、unicorn、zig）永远不会导致阻塞。在本机上
 `doctor` 只接受它真正能加载的 agent 文件名（Linux 上是 `j2c_agent.so`，macOS 上是
-`.dylib`，Windows 上是 `.dll`）；为其他操作系统遗留、或为其他 CPU 架构构建的产物
-都会被报告为 missing。
+`.dylib`，Windows 上是 `.dll`），并且文件头必须表明它是为本机 CPU 构建的；为其他
+操作系统遗留、为其他 CPU 架构构建、或格式无法识别的产物都会被报告为 missing。由于
+`native/build.sh` 只面向 x86-64，非 x86-64 主机（例如 ARM）无论 `native/build/lib`
+里放着什么，agent 都会被报告为 missing —— 动态路径在那里不可用，请改用模拟兜底或
+静态路径，两者都不需要 agent。
 
 ## 3. 恢复 —— 约 1–2 分钟
 
@@ -139,9 +142,11 @@ Java 版本够新，但 `JAVA_HOME` 没设；native agent 构建需要它。这�
 native 代码，因此能列出 native 方法、dump 解密后的常量，并把方法当纯函数 oracle
 来调用：
 
+把 `unicorn` 装进 setup 所用的那个解释器，并用它来跑 harness（启动器只包装 CLI 子命令）：
+
 ```bash
-pip install unicorn
-python3 py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
+(cd py && uv pip install unicorn)    # pip 兜底时用 python3 -m pip install unicorn
+py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```
 
 完整步骤见 [`emulation-recovery.md`](emulation-recovery.md)。

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -145,7 +145,7 @@ native 代码，因此能列出 native 方法、dump 解密后的常量，并把
 把 `unicorn` 装进 setup 所用的那个解释器，并用它来跑 harness（启动器只包装 CLI 子命令）：
 
 ```bash
-(cd py && uv pip install unicorn)    # pip 兜底时用 python3 -m pip install unicorn
+(cd py && uv pip install unicorn)    # 没有 uv？`scripts/j2c doctor` 会打印确切命令
 py/.venv/bin/python py/native_emulate/j2c_emu.py recover natives.bin --binary-json binary.json
 ```
 

--- a/docs/reviews/cli-doctor-setup.md
+++ b/docs/reviews/cli-doctor-setup.md
@@ -1,0 +1,135 @@
+# CLI doctor/setup review
+
+PR: https://github.com/gaoyu06/c2j-native-deobfuscator/pull/6
+
+Verdict: **ship as draft; must fix before merge**.
+
+The new entry point, help text, diagnostics, bilingual documentation, and
+Ghidra-free tests move the project in the right direction. The documented
+fresh-checkout path is not reliable yet, however, and `doctor` can both reject
+a usable runtime and approve an unusable installation.
+
+## Verification
+
+- `python3 -m j2c_dumper_cli --help`: passed in an isolated dependency path;
+  the default dynamic command is shown before the command list.
+- `python3 -m j2c_dumper_cli doctor`: ran and produced actionable setup
+  pointers; it exited 1 because the native agent was absent.
+- `python3 -m j2c_dumper_cli`: displayed help but exited 2.
+- Exact `python -m ...` commands could not be run on this Ubuntu environment
+  because only `python3` is installed. `setup.sh` also selects `python3` for its
+  fallback install but still prints `python -m ...` as the next command.
+- `python3 -m pytest py/j2c_dumper_cli/tests/ -q`: **27 passed** without
+  Ghidra.
+- `sh ./gradlew installDist --no-daemon`: passed on JDK 21; all three
+  generated CLI jars contain Java class-file major version 65.
+- `bash -n scripts/setup.sh`: passed.
+- PowerShell was unavailable, so `setup.ps1` was reviewed statically.
+
+## Must fix
+
+### 1. The setup path omits a required Python dependency
+
+`scripts/setup.sh` and `scripts/setup.ps1` install the five editable Python
+packages, but `py/binary_introspect/pyproject.toml` does not declare
+`capstone`. Importing the stage used by `recover` then fails:
+
+```text
+from binary_introspect.cli import main
+...
+ModuleNotFoundError: No module named 'capstone'
+```
+
+The failure occurs because `binary_introspect.arch` imports its built-in
+backends, which import `capstone` unconditionally. `doctor` does not probe this
+dependency, so it can print `Ready` before `recover` fails at binary
+introspection. Declare the dependency, install it through both setup paths,
+and add a post-setup/import check or an orchestration test that reaches this
+stage.
+
+### 2. The repository-wide JDK 17 to 21 bump is not required by this PR
+
+The JVM source contains no Java 21 API use, and this PR changes only the
+toolchain configuration. The bump makes every existing CLI distribution emit
+Java 21-only class files, unnecessarily dropping JDK 17 runtime compatibility.
+The desktop module proposed separately needs 21, while the existing JVM CLI
+modules are still designed for 17. Keep the shared CLI modules on 17 and scope
+21 to the desktop module if and when it lands. Align `doctor`, setup, CI, and
+the new documentation with the actual minimum.
+
+### 3. Native artifact checks do not establish readiness or idempotence
+
+Both setup scripts skip the native build when *any* of
+`j2c_agent.dll`, `j2c_agent.so`, or `j2c_agent.dylib` exists. They do not check
+the current OS, architecture, source freshness, or loadability. `doctor` uses
+the same any-suffix existence test. Consequently:
+
+- a stale agent remains stale unless the user knows to pass `--force`;
+- a DLL can make Linux `doctor` report the native agent as ready;
+- `native/build.sh` reads `HOST_ARCH` but always targets x86-64, while setup is
+  documented for Linux and macOS without an architecture qualification.
+
+This contradicts the setup comment that inputs are rebuilt when changed and
+the claim that `doctor` verifies default-path readiness. Select the
+host-specific filename, account for architecture, rebuild when inputs are
+newer (or always delegate incremental work to a build tool), and make
+`doctor` validate the artifact it will actually load.
+
+### 4. `doctor` treats warnings as missing requirements
+
+`Report.blocking` includes every non-optional status other than `OK`, including
+`WARN`. On a machine with Java 21 on `PATH` and no `JAVA_HOME`, the report
+therefore says `Missing: Java / JDK 21+` even though it just found Java 21.
+Either warnings must not block, or this condition must be represented as a
+required build precondition with accurate wording. Add an aggregate-report
+test for this case.
+
+### 5. The advertised no-argument and interpreter paths are not successful
+
+The no-argument module entry point prints the intended help but exits with
+status 2. The focused tests cover only `doctor`, not
+`python -m j2c_dumper_cli` or top-level help. In addition, the POSIX setup
+fallback installs with `python3` but tells users to invoke `python`, which is
+not present in a standard minimal Ubuntu environment.
+
+Make the no-argument help path exit 0, test both entry points, and consistently
+use or print the interpreter that setup actually selected (a managed virtual
+environment would make this deterministic).
+
+### 6. The Windows native setup has an undocumented and misleading prerequisite
+
+`setup.ps1` cannot build the agent directly: it requires `bash`, although the
+getting-started prerequisite list mentions only JDK, Python, and Zig. Its
+message recommends either Git Bash or WSL. WSL runs `native/build.sh` as Linux,
+selects a Linux target, and cannot directly use a normal Windows `JAVA_HOME`;
+it is not an equivalent way to produce the Windows DLL.
+
+Document and validate Git Bash specifically, or add a native Windows build
+invocation. A missing prerequisite for the default path should not end with an
+unqualified `Setup finished`.
+
+### 7. Narrow the readiness and output claims
+
+`doctor` currently checks versions and file existence. It does not execute the
+installed JVM launchers, import the default Python stages, validate the
+host/architecture of the agent, attempt to load it, or verify that a target
+command exercises useful code. Documentation should describe those checks
+precisely rather than call the result full default-path readiness.
+
+The getting-started guide also says a completed run yields real bytecode bodies
+for the native methods. Dynamic tracing covers only executed paths, and the
+rebuilder can preserve unverified output or fall back to stubs. State that the
+output contains best-effort recovered bodies for observed behavior and may
+require inspection or manual completion.
+
+## Checklist notes
+
+- Missing JVM-module and native-agent errors do point to `doctor` and both
+  setup scripts.
+- The English and Chinese READMEs now present manual CLI use as the default;
+  assisted adaptation is optional.
+- Ghidra is clearly labeled Advanced/optional, and the new doctor tests do not
+  require it.
+- Missing Zig is skipped with a clear warning in both scripts, but that leaves
+  the default dynamic path unavailable; the final setup message should say so
+  explicitly.

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -14,12 +14,12 @@ subprojects {
 
     extensions.configure<JavaPluginExtension> {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 
     extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
-        jvmToolchain(21)
+        jvmToolchain(17)
     }
 
     dependencies {

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -14,12 +14,12 @@ subprojects {
 
     extensions.configure<JavaPluginExtension> {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 
     extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
-        jvmToolchain(17)
+        jvmToolchain(21)
     }
 
     dependencies {

--- a/py/binary_introspect/pyproject.toml
+++ b/py/binary_introspect/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "lief>=0.15.1",
     "click>=8.1.7",
+    "capstone>=5.0.1",
 ]
 
 [project.scripts]

--- a/py/j2c_dumper_cli/j2c_dumper_cli/__main__.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point so `python -m j2c_dumper_cli` works (not just `...main`)."""
+
+from j2c_dumper_cli.main import app
+
+if __name__ == "__main__":
+    app()

--- a/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
@@ -1,0 +1,295 @@
+"""Environment diagnostics for the j2c-dumper CLI.
+
+The logic here is deliberately free of any UI framework so it can be unit
+tested without the recovery toolchain (or Ghidra) installed. Each probe
+returns a :class:`Check`; the CLI layer renders them.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Status values. "ok" = ready, "missing" = required but absent,
+# "warn" = present-but-suboptimal, "optional" = absent optional tool.
+STATUS_OK = "ok"
+STATUS_MISSING = "missing"
+STATUS_WARN = "warn"
+STATUS_OPTIONAL = "optional"
+
+MIN_JAVA = 21
+MIN_PYTHON = (3, 11)
+
+# JVM modules the default (dynamic) path invokes as installDist scripts.
+REQUIRED_JVM_MODULES = ("jar-parser", "trace-to-bytecode", "class-rebuilder")
+
+
+@dataclass
+class Check:
+    """One diagnostic line."""
+
+    name: str
+    status: str
+    detail: str = ""
+    fix: str = ""
+    optional: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.status == STATUS_OK
+
+
+@dataclass
+class Report:
+    """Aggregate of all checks."""
+
+    checks: list[Check] = field(default_factory=list)
+
+    def add(self, check: Check) -> None:
+        self.checks.append(check)
+
+    @property
+    def blocking(self) -> list[Check]:
+        """Required checks that are not satisfied."""
+        return [c for c in self.checks if not c.optional and c.status != STATUS_OK]
+
+    @property
+    def healthy(self) -> bool:
+        return not self.blocking
+
+
+# ------------------------------------------------------------------
+# Individual probes (each is easy to monkeypatch in tests)
+# ------------------------------------------------------------------
+
+def _parse_java_major(version_output: str) -> Optional[int]:
+    """Extract the Java feature version from `java -version` stderr text."""
+    m = re.search(r'version "?(\d+)(?:\.(\d+))?', version_output)
+    if not m:
+        return None
+    major = int(m.group(1))
+    # Legacy 1.x scheme (1.8 = Java 8); modern scheme reports the feature
+    # version directly (21, 17, ...).
+    if major == 1 and m.group(2):
+        return int(m.group(2))
+    return major
+
+
+def _java_executable() -> Optional[str]:
+    java_home = os.environ.get("JAVA_HOME")
+    if java_home:
+        suffix = ".exe" if os.name == "nt" else ""
+        candidate = Path(java_home) / "bin" / f"java{suffix}"
+        if candidate.exists():
+            return str(candidate)
+    return shutil.which("java")
+
+
+def _query_java_version(java_exe: str) -> str:
+    proc = subprocess.run(
+        [java_exe, "-version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # `java -version` prints to stderr.
+    return (proc.stderr or "") + (proc.stdout or "")
+
+
+def check_java() -> Check:
+    java_home = os.environ.get("JAVA_HOME")
+    java_exe = _java_executable()
+    if not java_exe:
+        return Check(
+            name="Java / JDK 21+",
+            status=STATUS_MISSING,
+            detail="no `java` on PATH and JAVA_HOME unset",
+            fix="install a JDK 21+ (Temurin / Adoptium) and set JAVA_HOME",
+        )
+    try:
+        major = _parse_java_major(_query_java_version(java_exe))
+    except Exception as exc:  # pragma: no cover - defensive
+        return Check(
+            name="Java / JDK 21+",
+            status=STATUS_MISSING,
+            detail=f"could not run `{java_exe} -version`: {exc}",
+            fix="install a JDK 21+ (Temurin / Adoptium) and set JAVA_HOME",
+        )
+    home_note = f"JAVA_HOME={java_home}" if java_home else "JAVA_HOME is not set"
+    if major is None:
+        return Check(
+            name="Java / JDK 21+",
+            status=STATUS_WARN,
+            detail=f"found {java_exe} but could not parse its version; {home_note}",
+            fix="verify `java -version` reports 21 or newer",
+        )
+    if major < MIN_JAVA:
+        return Check(
+            name="Java / JDK 21+",
+            status=STATUS_MISSING,
+            detail=f"found Java {major} at {java_exe}; need {MIN_JAVA}+; {home_note}",
+            fix=f"install a JDK {MIN_JAVA}+ and point JAVA_HOME at it",
+        )
+    if not java_home:
+        return Check(
+            name="Java / JDK 21+",
+            status=STATUS_WARN,
+            detail=f"Java {major} at {java_exe}, but JAVA_HOME is not set "
+                   "(the native agent build needs it)",
+            fix="set JAVA_HOME to your JDK install directory",
+        )
+    return Check(
+        name="Java / JDK 21+",
+        status=STATUS_OK,
+        detail=f"Java {major} at {java_exe}; {home_note}",
+    )
+
+
+def check_python() -> Check:
+    info = sys.version_info
+    ver = f"{info[0]}.{info[1]}.{info[2]}"
+    if (info[0], info[1]) < MIN_PYTHON:
+        return Check(
+            name="Python 3.11+",
+            status=STATUS_MISSING,
+            detail=f"running Python {ver}; need "
+                   f"{MIN_PYTHON[0]}.{MIN_PYTHON[1]}+",
+            fix="run the CLI under Python 3.11 or newer",
+        )
+    return Check(
+        name="Python 3.11+",
+        status=STATUS_OK,
+        detail=f"Python {ver} at {sys.executable}",
+    )
+
+
+def _jvm_install_script(root: Path, module: str) -> Path:
+    suffix = ".bat" if os.name == "nt" else ""
+    return root / "jvm" / module / "build" / "install" / module / "bin" / f"{module}{suffix}"
+
+
+def check_jvm_modules(root: Path) -> Check:
+    missing = [m for m in REQUIRED_JVM_MODULES
+               if not _jvm_install_script(root, m).exists()]
+    if not missing:
+        return Check(
+            name="JVM modules (installDist)",
+            status=STATUS_OK,
+            detail=f"all built: {', '.join(REQUIRED_JVM_MODULES)}",
+        )
+    return Check(
+        name="JVM modules (installDist)",
+        status=STATUS_MISSING,
+        detail=f"not built: {', '.join(missing)}",
+        fix="run scripts/setup.sh (or scripts/setup.ps1), "
+            "or `cd jvm && ./gradlew installDist`",
+    )
+
+
+def check_native_agent(root: Path) -> Check:
+    libdir = root / "native" / "build" / "lib"
+    for name in ("j2c_agent.dll", "j2c_agent.so", "j2c_agent.dylib"):
+        if (libdir / name).exists():
+            return Check(
+                name="Native JVMTI agent",
+                status=STATUS_OK,
+                detail=f"found {libdir / name}",
+            )
+    return Check(
+        name="Native JVMTI agent",
+        status=STATUS_MISSING,
+        detail=f"no j2c_agent.(so|dll|dylib) under {libdir}",
+        fix="run scripts/setup.sh (needs JAVA_HOME + zig), "
+            "or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`",
+    )
+
+
+def check_ghidra() -> Check:
+    ghidra_dir = os.environ.get("GHIDRA_INSTALL_DIR")
+    if ghidra_dir and Path(ghidra_dir).exists():
+        return Check(
+            name="Ghidra (optional)",
+            status=STATUS_OK,
+            detail=f"GHIDRA_INSTALL_DIR={ghidra_dir}",
+            optional=True,
+        )
+    for tool in ("analyzeHeadless", "analyzeHeadless.bat"):
+        found = shutil.which(tool)
+        if found:
+            return Check(
+                name="Ghidra (optional)",
+                status=STATUS_OK,
+                detail=f"found {found}",
+                optional=True,
+            )
+    return Check(
+        name="Ghidra (optional)",
+        status=STATUS_OPTIONAL,
+        detail="not found; only needed for the static (Advanced) path",
+        fix="install Ghidra 11.x and set GHIDRA_INSTALL_DIR (optional)",
+        optional=True,
+    )
+
+
+def check_unicorn() -> Check:
+    try:
+        import unicorn  # noqa: F401
+    except Exception:
+        return Check(
+            name="unicorn (optional)",
+            status=STATUS_OPTIONAL,
+            detail="not installed; only needed for the emulation fallback",
+            fix="pip install unicorn (optional)",
+            optional=True,
+        )
+    return Check(
+        name="unicorn (optional)",
+        status=STATUS_OK,
+        detail="importable",
+        optional=True,
+    )
+
+
+def check_zig() -> Check:
+    zig_env = os.environ.get("ZIG")
+    if zig_env and Path(zig_env).exists():
+        return Check(
+            name="zig (optional)",
+            status=STATUS_OK,
+            detail=f"ZIG={zig_env}",
+            optional=True,
+        )
+    found = shutil.which("zig")
+    if found:
+        return Check(
+            name="zig (optional)",
+            status=STATUS_OK,
+            detail=f"found {found}",
+            optional=True,
+        )
+    return Check(
+        name="zig (optional)",
+        status=STATUS_OPTIONAL,
+        detail="not found; only needed to build the native agent from source",
+        fix="install zig 0.16.x or set ZIG to its path (optional)",
+        optional=True,
+    )
+
+
+def build_report(root: Path) -> Report:
+    """Run every probe and return an aggregate report."""
+    report = Report()
+    report.add(check_java())
+    report.add(check_python())
+    report.add(check_jvm_modules(root))
+    report.add(check_native_agent(root))
+    report.add(check_ghidra())
+    report.add(check_unicorn())
+    report.add(check_zig())
+    return report

--- a/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
@@ -8,6 +8,7 @@ returns a :class:`Check`; the CLI layer renders them.
 from __future__ import annotations
 
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -184,24 +185,52 @@ def check_python() -> Check:
     )
 
 
-def check_python_recover_deps() -> Check:
+def venv_python(root: Optional[Path]) -> Optional[Path]:
+    """The uv-managed interpreter under ``py/.venv``, if it exists.
+
+    ``scripts/setup.sh`` runs ``uv sync``, which installs the packages into this
+    interpreter — not the system ``python3``. Probes point users at it (via the
+    ``scripts/j2c`` launcher) when the current interpreter lacks the packages.
+    """
+    if root is None:
+        return None
+    if os.name == "nt":
+        candidate = root / "py" / ".venv" / "Scripts" / "python.exe"
+    else:
+        candidate = root / "py" / ".venv" / "bin" / "python"
+    return candidate if candidate.exists() else None
+
+
+def check_python_recover_deps(root: Optional[Path] = None) -> Check:
     """Import the Python stage the default path runs (binary introspection).
 
     Importing ``binary_introspect.cli`` pulls in its architecture backends,
     which require ``capstone`` and ``lief``. Probing it here catches a
     half-installed workspace before ``recover`` fails mid-pipeline.
+
+    When the import fails but a uv-managed ``py/.venv`` exists (and is not the
+    interpreter running this probe), the packages are almost certainly installed
+    there: the real fix is to run the *right* interpreter, so the message says
+    so instead of only suggesting a reinstall.
     """
     name = "Python recover deps (capstone, lief)"
     try:
         import binary_introspect.cli  # noqa: F401
     except Exception as exc:
         missing = getattr(exc, "name", "") or str(exc)
+        venv = venv_python(root)
+        if venv is not None and Path(sys.executable).resolve() != venv.resolve():
+            fix = (f"the workspace is installed in {venv.parent.parent}; run it "
+                   "through that interpreter — use `scripts/j2c doctor` "
+                   "(or `scripts\\j2c.ps1 doctor` on Windows), which selects it")
+        else:
+            fix = ("run scripts/setup.sh (or scripts/setup.ps1), or "
+                   "`pip install -e py/binary_introspect` (installs capstone + lief)")
         return Check(
             name=name,
             status=STATUS_MISSING,
-            detail=f"cannot import binary_introspect.cli: {missing}",
-            fix="run scripts/setup.sh (or scripts/setup.ps1), or "
-                "`pip install -e py/binary_introspect` (installs capstone + lief)",
+            detail=f"cannot import binary_introspect.cli under {sys.executable}: {missing}",
+            fix=fix,
         )
     return Check(
         name=name,
@@ -257,6 +286,74 @@ _MIN_AGENT_BYTES = 4096
 _ALL_AGENT_NAMES = ("j2c_agent.so", "j2c_agent.dylib", "j2c_agent.dll")
 
 
+def host_machine(machine: Optional[str] = None) -> str:
+    """Normalise the host CPU architecture to a small, comparable label.
+
+    ``platform.machine()`` reports many spellings for the same ISA
+    (``x86_64``/``amd64``/``AMD64``, ``aarch64``/``arm64``). Collapsing them
+    lets the native-agent probe compare the host against what the artifact was
+    actually built for.
+    """
+    m = (machine if machine is not None else platform.machine()).lower()
+    if m in ("x86_64", "amd64", "x64", "em64t"):
+        return "x86_64"
+    if m in ("aarch64", "arm64", "armv8", "armv8l"):
+        return "arm64"
+    if m in ("i386", "i486", "i586", "i686", "x86"):
+        return "x86"
+    if m.startswith("arm"):
+        return "arm"
+    return m or "unknown"
+
+
+# ELF e_machine / Mach-O cputype / PE machine values, mapped to the same
+# normalised labels host_machine() returns. Only the architectures the build
+# can plausibly emit are listed; anything else stays unknown (and unenforced).
+_ELF_MACHINES = {0x03: "x86", 0x3E: "x86_64", 0x28: "arm", 0xB7: "arm64"}
+_MACHO_CPUS = {0x00000007: "x86", 0x01000007: "x86_64",
+               0x0000000C: "arm", 0x0100000C: "arm64"}
+_PE_MACHINES = {0x014C: "x86", 0x8664: "x86_64", 0x01C0: "arm",
+                0x01C4: "arm", 0xAA64: "arm64"}
+
+
+def agent_arch(path: Path) -> Optional[str]:
+    """Read a shared library's target CPU from its header (ELF/Mach-O/PE).
+
+    Returns a :func:`host_machine`-style label, or ``None`` when the format or
+    architecture is unrecognised (in which case the caller does not enforce an
+    architecture match — it only blocks on a *known* mismatch).
+    """
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(4096)
+    except OSError:
+        return None
+    if len(head) < 6:
+        return None
+
+    if head[:4] == b"\x7fELF":  # ELF (Linux, etc.)
+        endian = "little" if head[5] == 1 else "big"
+        if len(head) < 20:
+            return None
+        return _ELF_MACHINES.get(int.from_bytes(head[18:20], endian))
+
+    magic = head[:4]
+    if magic in (b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe"):  # Mach-O little-endian
+        return _MACHO_CPUS.get(int.from_bytes(head[4:8], "little"))
+    if magic in (b"\xfe\xed\xfa\xcf", b"\xfe\xed\xfa\xce"):  # Mach-O big-endian
+        return _MACHO_CPUS.get(int.from_bytes(head[4:8], "big"))
+
+    if head[:2] == b"MZ":  # PE / COFF (Windows DLL)
+        if len(head) < 0x40:
+            return None
+        pe_off = int.from_bytes(head[0x3C:0x40], "little")
+        if pe_off + 6 > len(head) or head[pe_off:pe_off + 4] != b"PE\x00\x00":
+            return None
+        return _PE_MACHINES.get(int.from_bytes(head[pe_off + 4:pe_off + 6], "little"))
+
+    return None
+
+
 def check_native_agent(root: Path) -> Check:
     libdir = root / "native" / "build" / "lib"
     want = host_agent_name()
@@ -273,10 +370,24 @@ def check_native_agent(root: Path) -> Check:
                 detail=f"{target} is only {size} bytes; looks empty or truncated",
                 fix="delete it and rebuild: " + fix,
             )
+        # native/build.sh targets x86-64 only. On another host CPU it emits an
+        # artifact with the right *name* but the wrong machine code, which the
+        # JVM here cannot load — so a known architecture mismatch is not ready.
+        host = host_machine()
+        built = agent_arch(target)
+        if built is not None and built != host:
+            return Check(
+                name="Native JVMTI agent",
+                status=STATUS_MISSING,
+                detail=f"{target} is built for {built} but this host is {host}; "
+                       "native/build.sh targets x86-64 and its output cannot be "
+                       "loaded here",
+                fix="rebuild for this architecture: " + fix,
+            )
         return Check(
             name="Native JVMTI agent",
             status=STATUS_OK,
-            detail=f"found {target}",
+            detail=f"found {target}" + (f" ({built})" if built else ""),
         )
 
     # A leftover build for another OS must not read as ready.
@@ -375,7 +486,7 @@ def build_report(root: Path) -> Report:
     report = Report()
     report.add(check_java())
     report.add(check_python())
-    report.add(check_python_recover_deps())
+    report.add(check_python_recover_deps(root))
     report.add(check_jvm_modules(root))
     report.add(check_native_agent(root))
     report.add(check_ghidra())

--- a/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
@@ -224,8 +224,11 @@ def check_python_recover_deps(root: Optional[Path] = None) -> Check:
                    "through that interpreter — use `scripts/j2c doctor` "
                    "(or `scripts\\j2c.ps1 doctor` on Windows), which selects it")
         else:
+            # Name the interpreter in the manual fallback too: a bare `pip` is
+            # whichever one is on PATH, which may not be this one.
             fix = ("run scripts/setup.sh (or scripts/setup.ps1), or "
-                   "`pip install -e py/binary_introspect` (installs capstone + lief)")
+                   f"`{sys.executable} -m pip install -e py/binary_introspect` "
+                   "(installs capstone + lief)")
         return Check(
             name=name,
             status=STATUS_MISSING,

--- a/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
@@ -23,8 +23,12 @@ STATUS_MISSING = "missing"
 STATUS_WARN = "warn"
 STATUS_OPTIONAL = "optional"
 
-MIN_JAVA = 21
+MIN_JAVA = 17
 MIN_PYTHON = (3, 11)
+
+# The name shown for the Java check; kept in one place so the required
+# minimum stays consistent between the probe and its messages.
+JAVA_CHECK_NAME = f"Java / JDK {MIN_JAVA}+"
 
 # JVM modules the default (dynamic) path invokes as installDist scripts.
 REQUIRED_JVM_MODULES = ("jar-parser", "trace-to-bytecode", "class-rebuilder")
@@ -56,8 +60,19 @@ class Report:
 
     @property
     def blocking(self) -> list[Check]:
-        """Required checks that are not satisfied."""
-        return [c for c in self.checks if not c.optional and c.status != STATUS_OK]
+        """Required checks that actually block the default path.
+
+        Only a required check reported ``MISSING`` blocks. A ``WARN`` is a
+        non-fatal caveat (for example, Java is new enough but ``JAVA_HOME`` is
+        unset) and must not flip the required-ready bit; optional tools never
+        block.
+        """
+        return [c for c in self.checks if not c.optional and c.status == STATUS_MISSING]
+
+    @property
+    def warnings(self) -> list[Check]:
+        """Required checks that are usable but flagged with a caveat."""
+        return [c for c in self.checks if not c.optional and c.status == STATUS_WARN]
 
     @property
     def healthy(self) -> bool:
@@ -107,45 +122,45 @@ def check_java() -> Check:
     java_exe = _java_executable()
     if not java_exe:
         return Check(
-            name="Java / JDK 21+",
+            name=JAVA_CHECK_NAME,
             status=STATUS_MISSING,
             detail="no `java` on PATH and JAVA_HOME unset",
-            fix="install a JDK 21+ (Temurin / Adoptium) and set JAVA_HOME",
+            fix=f"install a JDK {MIN_JAVA}+ (Temurin / Adoptium) and set JAVA_HOME",
         )
     try:
         major = _parse_java_major(_query_java_version(java_exe))
     except Exception as exc:  # pragma: no cover - defensive
         return Check(
-            name="Java / JDK 21+",
+            name=JAVA_CHECK_NAME,
             status=STATUS_MISSING,
             detail=f"could not run `{java_exe} -version`: {exc}",
-            fix="install a JDK 21+ (Temurin / Adoptium) and set JAVA_HOME",
+            fix=f"install a JDK {MIN_JAVA}+ (Temurin / Adoptium) and set JAVA_HOME",
         )
     home_note = f"JAVA_HOME={java_home}" if java_home else "JAVA_HOME is not set"
     if major is None:
         return Check(
-            name="Java / JDK 21+",
+            name=JAVA_CHECK_NAME,
             status=STATUS_WARN,
             detail=f"found {java_exe} but could not parse its version; {home_note}",
-            fix="verify `java -version` reports 21 or newer",
+            fix=f"verify `java -version` reports {MIN_JAVA} or newer",
         )
     if major < MIN_JAVA:
         return Check(
-            name="Java / JDK 21+",
+            name=JAVA_CHECK_NAME,
             status=STATUS_MISSING,
             detail=f"found Java {major} at {java_exe}; need {MIN_JAVA}+; {home_note}",
             fix=f"install a JDK {MIN_JAVA}+ and point JAVA_HOME at it",
         )
     if not java_home:
         return Check(
-            name="Java / JDK 21+",
+            name=JAVA_CHECK_NAME,
             status=STATUS_WARN,
             detail=f"Java {major} at {java_exe}, but JAVA_HOME is not set "
                    "(the native agent build needs it)",
             fix="set JAVA_HOME to your JDK install directory",
         )
     return Check(
-        name="Java / JDK 21+",
+        name=JAVA_CHECK_NAME,
         status=STATUS_OK,
         detail=f"Java {major} at {java_exe}; {home_note}",
     )
@@ -166,6 +181,32 @@ def check_python() -> Check:
         name="Python 3.11+",
         status=STATUS_OK,
         detail=f"Python {ver} at {sys.executable}",
+    )
+
+
+def check_python_recover_deps() -> Check:
+    """Import the Python stage the default path runs (binary introspection).
+
+    Importing ``binary_introspect.cli`` pulls in its architecture backends,
+    which require ``capstone`` and ``lief``. Probing it here catches a
+    half-installed workspace before ``recover`` fails mid-pipeline.
+    """
+    name = "Python recover deps (capstone, lief)"
+    try:
+        import binary_introspect.cli  # noqa: F401
+    except Exception as exc:
+        missing = getattr(exc, "name", "") or str(exc)
+        return Check(
+            name=name,
+            status=STATUS_MISSING,
+            detail=f"cannot import binary_introspect.cli: {missing}",
+            fix="run scripts/setup.sh (or scripts/setup.ps1), or "
+                "`pip install -e py/binary_introspect` (installs capstone + lief)",
+        )
+    return Check(
+        name=name,
+        status=STATUS_OK,
+        detail="binary_introspect stage imports (capstone + lief present)",
     )
 
 
@@ -192,21 +233,68 @@ def check_jvm_modules(root: Path) -> Check:
     )
 
 
+def host_agent_name(platform: Optional[str] = None) -> str:
+    """The JVMTI agent filename this host can actually load.
+
+    A ``.so`` on Windows or a ``.dll`` on Linux belongs to another platform and
+    cannot be loaded here, so the default path only ever looks for the single
+    host-matching name.
+    """
+    plat = platform if platform is not None else sys.platform
+    if plat.startswith("win") or os.name == "nt":
+        return "j2c_agent.dll"
+    if plat == "darwin":
+        return "j2c_agent.dylib"
+    return "j2c_agent.so"
+
+
+# Agents smaller than this are almost certainly a truncated or placeholder
+# build rather than a real shared library, so treat them as not ready.
+_MIN_AGENT_BYTES = 4096
+
+# The three names the build can emit; used only to explain a wrong-platform
+# leftover, never to accept one.
+_ALL_AGENT_NAMES = ("j2c_agent.so", "j2c_agent.dylib", "j2c_agent.dll")
+
+
 def check_native_agent(root: Path) -> Check:
     libdir = root / "native" / "build" / "lib"
-    for name in ("j2c_agent.dll", "j2c_agent.so", "j2c_agent.dylib"):
-        if (libdir / name).exists():
+    want = host_agent_name()
+    fix = ("run scripts/setup.sh (needs JAVA_HOME + zig), "
+           "or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`")
+    target = libdir / want
+
+    if target.exists():
+        size = target.stat().st_size
+        if size < _MIN_AGENT_BYTES:
             return Check(
                 name="Native JVMTI agent",
-                status=STATUS_OK,
-                detail=f"found {libdir / name}",
+                status=STATUS_MISSING,
+                detail=f"{target} is only {size} bytes; looks empty or truncated",
+                fix="delete it and rebuild: " + fix,
             )
+        return Check(
+            name="Native JVMTI agent",
+            status=STATUS_OK,
+            detail=f"found {target}",
+        )
+
+    # A leftover build for another OS must not read as ready.
+    stray = [n for n in _ALL_AGENT_NAMES if n != want and (libdir / n).exists()]
+    if stray:
+        return Check(
+            name="Native JVMTI agent",
+            status=STATUS_MISSING,
+            detail=f"found {', '.join(stray)} under {libdir} but this host needs "
+                   f"{want}; a wrong-platform agent cannot be loaded here",
+            fix="rebuild on this host: " + fix,
+        )
+
     return Check(
         name="Native JVMTI agent",
         status=STATUS_MISSING,
-        detail=f"no j2c_agent.(so|dll|dylib) under {libdir}",
-        fix="run scripts/setup.sh (needs JAVA_HOME + zig), "
-            "or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`",
+        detail=f"no {want} under {libdir}",
+        fix=fix,
     )
 
 
@@ -287,6 +375,7 @@ def build_report(root: Path) -> Report:
     report = Report()
     report.add(check_java())
     report.add(check_python())
+    report.add(check_python_recover_deps())
     report.add(check_jvm_modules(root))
     report.add(check_native_agent(root))
     report.add(check_ghidra())

--- a/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
@@ -285,6 +285,11 @@ _MIN_AGENT_BYTES = 4096
 # leftover, never to accept one.
 _ALL_AGENT_NAMES = ("j2c_agent.so", "j2c_agent.dylib", "j2c_agent.dll")
 
+# CPU architectures this project can actually build an agent for.
+# ``native/build.sh`` passes `-target x86_64-*` for every host OS, so x86-64 is
+# the only architecture whose agent the default (dynamic) path can rely on.
+SUPPORTED_AGENT_MACHINES = ("x86_64",)
+
 
 def host_machine(machine: Optional[str] = None) -> str:
     """Normalise the host CPU architecture to a small, comparable label.
@@ -357,9 +362,36 @@ def agent_arch(path: Path) -> Optional[str]:
 def check_native_agent(root: Path) -> Check:
     libdir = root / "native" / "build" / "lib"
     want = host_agent_name()
+    host = host_machine()
+    supported = "/".join(SUPPORTED_AGENT_MACHINES)
     fix = ("run scripts/setup.sh (needs JAVA_HOME + zig), "
            "or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`")
     target = libdir / want
+
+    # The default path loads the agent into *this* JVM, so it needs an agent
+    # built for this CPU — and native/build.sh can only build x86-64. On any
+    # other host there is no supported way to produce one, so nothing found in
+    # build/lib proves the dynamic path is usable: an x86-64 artifact cannot be
+    # loaded here, and a same-arch one did not come from this build. Report the
+    # agent as missing rather than guessing, and point at the paths that need
+    # no agent.
+    if host not in SUPPORTED_AGENT_MACHINES:
+        present = [n for n in _ALL_AGENT_NAMES if (libdir / n).exists()]
+        found = ""
+        if present:
+            arch = agent_arch(libdir / present[0])
+            found = (f"; ignoring {', '.join(present)} under {libdir}"
+                     + (f" (built for {arch})" if arch else ""))
+        return Check(
+            name="Native JVMTI agent",
+            status=STATUS_MISSING,
+            detail=f"this host is {host}, but native/build.sh only targets "
+                   f"{supported}, so the dynamic path has no agent it can "
+                   f"load here{found}",
+            fix=f"use the emulation fallback or the static path (neither needs "
+                f"the agent), run the dynamic path on {supported}, or port "
+                f"native/build.sh to {host}",
+        )
 
     if target.exists():
         size = target.stat().st_size
@@ -370,12 +402,19 @@ def check_native_agent(root: Path) -> Check:
                 detail=f"{target} is only {size} bytes; looks empty or truncated",
                 fix="delete it and rebuild: " + fix,
             )
-        # native/build.sh targets x86-64 only. On another host CPU it emits an
-        # artifact with the right *name* but the wrong machine code, which the
-        # JVM here cannot load — so a known architecture mismatch is not ready.
-        host = host_machine()
         built = agent_arch(target)
-        if built is not None and built != host:
+        # An agent whose architecture cannot be read is not a library this JVM
+        # is known to be able to load, so it does not count as ready either.
+        if built is None:
+            return Check(
+                name="Native JVMTI agent",
+                status=STATUS_MISSING,
+                detail=f"cannot read a target architecture from {target}; it is "
+                       "not a recognised ELF/Mach-O/PE shared library, so it "
+                       "may not load here",
+                fix="delete it and rebuild: " + fix,
+            )
+        if built != host:
             return Check(
                 name="Native JVMTI agent",
                 status=STATUS_MISSING,
@@ -387,7 +426,7 @@ def check_native_agent(root: Path) -> Check:
         return Check(
             name="Native JVMTI agent",
             status=STATUS_OK,
-            detail=f"found {target}" + (f" ({built})" if built else ""),
+            detail=f"found {target} ({built})",
         )
 
     # A leftover build for another OS must not read as ready.
@@ -444,7 +483,11 @@ def check_unicorn() -> Check:
             name="unicorn (optional)",
             status=STATUS_OPTIONAL,
             detail="not installed; only needed for the emulation fallback",
-            fix="pip install unicorn (optional)",
+            # Name the interpreter explicitly: unicorn must land in the one the
+            # emulation harness runs under, not in whichever `pip` is on PATH.
+            fix=f"install it for this interpreter — `(cd py && uv pip install "
+                f"unicorn)`, or `{sys.executable} -m pip install unicorn` "
+                f"(optional)",
             optional=True,
         )
     return Check(

--- a/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/doctor.py
@@ -419,8 +419,7 @@ def check_native_agent(root: Path) -> Check:
                 name="Native JVMTI agent",
                 status=STATUS_MISSING,
                 detail=f"{target} is built for {built} but this host is {host}; "
-                       "native/build.sh targets x86-64 and its output cannot be "
-                       "loaded here",
+                       "an agent for another CPU cannot be loaded here",
                 fix="rebuild for this architecture: " + fix,
             )
         return Check(

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -15,10 +15,27 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from j2c_dumper_cli import doctor as doctor_mod
+
+HELP = """\
+Recover JNI-native transpiled JARs back to readable JVM bytecode.
+
+DEFAULT PATH (dynamic): if the JAR can be launched, run
+
+    python -m j2c_dumper_cli recover IN.jar -o OUT.jar --run-cmd "java -jar IN.jar"
+
+FIRST TIME? run `doctor` to check your toolchain, then `scripts/setup.sh`
+(or `scripts/setup.ps1` on Windows) to build everything.
+
+FALLBACK (no live run): the emulation path needs no JVM and no Ghidra.
+ADVANCED (offline, needs Ghidra): the static path — see `--help` of the
+individual stage commands and docs/getting-started.md.
+"""
+
 app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
-    help="Reverse-engineer native-obfuscator-style transpiled jars.",
+    help=HELP,
 )
 console = Console(stderr=True)
 
@@ -43,8 +60,10 @@ def jvm_bin(name: str) -> Path:
     candidate = root / "jvm" / name / "build" / "install" / name / "bin" / f"{name}{suffix}"
     if not candidate.exists():
         raise FileNotFoundError(
-            f"JVM module '{name}' not built. Run "
-            f"`./gradlew :{name}:installDist` from jvm/ first."
+            f"JVM module '{name}' is not built.\n"
+            f"  Fix: run scripts/setup.sh (or scripts/setup.ps1 on Windows),\n"
+            f"       or `cd jvm && ./gradlew :{name}:installDist`.\n"
+            f"  Diagnose: python -m j2c_dumper_cli doctor"
         )
     return candidate
 
@@ -53,12 +72,21 @@ def native_lib() -> Path:
     """Path to the JVMTI agent shared library, if built."""
     root = project_root()
     libdir = root / "native" / "build" / "lib"
+    hint = (
+        "  Fix: run scripts/setup.sh (or scripts/setup.ps1 on Windows),\n"
+        "       or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`.\n"
+        "  Diagnose: python -m j2c_dumper_cli doctor"
+    )
     if not libdir.exists():
-        raise FileNotFoundError("native agent not built. Run native/build.sh first.")
+        raise FileNotFoundError(
+            "Native JVMTI agent is not built (the dynamic path needs it).\n" + hint
+        )
     for name in ("j2c_agent.dll", "j2c_agent.so", "j2c_agent.dylib"):
         if (libdir / name).exists():
             return libdir / name
-    raise FileNotFoundError(f"No j2c_agent.* under {libdir}")
+    raise FileNotFoundError(
+        f"Native JVMTI agent is not built: no j2c_agent.* under {libdir}.\n" + hint
+    )
 
 
 def run(cmd: list[str | Path], **kwargs) -> subprocess.CompletedProcess:
@@ -140,6 +168,34 @@ def _run_rebuild(input: Path, recovered: Path, output: Path, manifest: Optional[
     run(args)
 
 
+def _preflight_recover(run_cmd: Optional[str], no_dynamic: bool) -> None:
+    """Fail early with a clear pointer when the toolchain the default path
+    needs is missing, instead of a mid-pipeline traceback."""
+    try:
+        root = project_root()
+    except RuntimeError:
+        return  # non-fatal; the stage that needs it will report specifically
+
+    problems: list[str] = []
+    jvm_check = doctor_mod.check_jvm_modules(root)
+    if not jvm_check.ok:
+        problems.append(f"{jvm_check.detail} — {jvm_check.fix}")
+    if run_cmd and not no_dynamic:
+        agent_check = doctor_mod.check_native_agent(root)
+        if not agent_check.ok:
+            problems.append(f"{agent_check.detail} — {agent_check.fix}")
+
+    if problems:
+        console.print("[bold red]recover cannot start:[/] required build "
+                      "artifacts are missing.")
+        for p in problems:
+            console.print(f"  - {p}")
+        console.print("Run [bold]python -m j2c_dumper_cli doctor[/] for a full "
+                      "report, then [bold]scripts/setup.sh[/] "
+                      "(or scripts/setup.ps1 on Windows).")
+        raise typer.Exit(code=2)
+
+
 @app.command("parse-jar")
 def cli_parse_jar(
     jar: Path = typer.Argument(..., exists=True, dir_okay=False),
@@ -210,6 +266,56 @@ def cli_rebuild(
 
 
 @app.command()
+def doctor() -> None:
+    """Check that your toolchain is ready for the default (dynamic) path.
+
+    Reports Java/JDK, Python, the built JVM modules and native agent, plus
+    the optional tools (Ghidra, unicorn, zig). Exits non-zero if a required
+    piece is missing so it is safe to gate a setup script on it.
+    """
+    from rich.table import Table
+
+    try:
+        root = project_root()
+    except RuntimeError:
+        root = Path.cwd()
+
+    report = doctor_mod.build_report(root)
+
+    symbol = {
+        doctor_mod.STATUS_OK: "[green]OK[/]",
+        doctor_mod.STATUS_MISSING: "[red]MISSING[/]",
+        doctor_mod.STATUS_WARN: "[yellow]WARN[/]",
+        doctor_mod.STATUS_OPTIONAL: "[dim]optional[/]",
+    }
+
+    table = Table(title="j2c-dumper doctor", show_lines=False)
+    table.add_column("Check", style="bold")
+    table.add_column("Status")
+    table.add_column("Detail")
+    for c in report.checks:
+        table.add_row(c.name, symbol.get(c.status, c.status), c.detail)
+    console.print(table)
+
+    fixes = [c for c in report.checks if c.fix and c.status != doctor_mod.STATUS_OK]
+    if fixes:
+        console.print("\n[bold]Next steps:[/]")
+        for c in fixes:
+            tag = "(optional) " if c.optional else ""
+            console.print(f"  - {tag}{c.name}: {c.fix}")
+
+    if report.healthy:
+        console.print("\n[bold green]Ready.[/] Try: "
+                      "python -m j2c_dumper_cli recover IN.jar -o OUT.jar "
+                      "--run-cmd \"java -jar IN.jar\"")
+    else:
+        missing = ", ".join(c.name for c in report.blocking)
+        console.print(f"\n[bold red]Not ready.[/] Missing: {missing}. "
+                      "Run scripts/setup.sh (or scripts/setup.ps1) to fix.")
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def recover(
     jar: Path = typer.Argument(..., exists=True, dir_okay=False, help="Input (obfuscated) jar"),
     lib: Optional[Path] = typer.Option(None, "--lib", help="Native library (auto-extracted from jar if omitted)"),
@@ -221,7 +327,13 @@ def recover(
     ghidra_dump: Optional[Path] = typer.Option(None, "--ghidra-dump", help="Pre-generated Ghidra dump JSON (skip Ghidra invocation)"),
     workdir: Optional[Path] = typer.Option(None, "--workdir", help="Working directory for intermediate files"),
 ):
-    """One-shot orchestration: parse → introspect → merge → trace → recover → rebuild."""
+    """One-shot orchestration: parse → introspect → merge → trace → recover → rebuild.
+
+    This is the default path. With --run-cmd it runs the JVMTI agent against a
+    live launch of the JAR (dynamic recovery). Without a runnable JAR, use the
+    emulation fallback instead — see docs/getting-started.md.
+    """
+    _preflight_recover(run_cmd=run_cmd, no_dynamic=no_dynamic)
     if workdir is None:
         workdir = Path(tempfile.mkdtemp(prefix="j2c-"))
     workdir.mkdir(parents=True, exist_ok=True)

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -17,20 +18,39 @@ from rich.console import Console
 
 from j2c_dumper_cli import doctor as doctor_mod
 
-# The interpreter name setup selects and that is present on each platform:
-# a minimal POSIX environment ships `python3` (not `python`); Windows ships
-# `python`. Runtime messages echo the one that will actually work here.
-PYCMD = "python" if os.name == "nt" else "python3"
+
+def _cli_invocation() -> str:
+    """How to re-invoke this CLI in a way that actually works here.
+
+    `scripts/setup.sh` installs the packages into `py/.venv` (via uv), so a
+    bare ``python3 -m j2c_dumper_cli`` on a *system* interpreter would not find
+    them. Every hint the CLI prints must therefore point at an interpreter that
+    has the packages:
+
+    * when launched through ``scripts/j2c`` (or ``scripts/j2c.ps1``), echo that
+      launcher — it resolves the venv/pip interpreter itself;
+    * otherwise echo :data:`sys.executable`, which by definition already
+      imported this module, so the command is guaranteed to run.
+    """
+    launcher = os.environ.get("J2C_CMD")
+    if launcher:
+        return launcher
+    exe = sys.executable or ("python" if os.name == "nt" else "python3")
+    return f"{shlex.quote(exe)} -m j2c_dumper_cli"
+
+
+CLI = _cli_invocation()
 
 HELP = f"""\
 Recover JNI-native transpiled JARs back to readable JVM bytecode.
 
 DEFAULT PATH (dynamic): if the JAR can be launched, run
 
-    {PYCMD} -m j2c_dumper_cli recover IN.jar -o OUT.jar --run-cmd "java -jar IN.jar"
+    scripts/j2c recover IN.jar -o OUT.jar --run-cmd "java -jar IN.jar"
 
-FIRST TIME? run `doctor` to check your toolchain, then `scripts/setup.sh`
-(or `scripts/setup.ps1` on Windows) to build everything.
+FIRST TIME? run `scripts/setup.sh` (or `scripts/setup.ps1` on Windows) to build
+everything, then `scripts/j2c doctor` to check your toolchain. The `scripts/j2c`
+launcher runs the interpreter the setup step installed the packages into.
 
 FALLBACK (no live run): the emulation path needs no JVM and no Ghidra.
 ADVANCED (offline, needs Ghidra): the static path — see `--help` of the
@@ -77,7 +97,7 @@ def jvm_bin(name: str) -> Path:
             f"JVM module '{name}' is not built.\n"
             f"  Fix: run scripts/setup.sh (or scripts/setup.ps1 on Windows),\n"
             f"       or `cd jvm && ./gradlew :{name}:installDist`.\n"
-            f"  Diagnose: {PYCMD} -m j2c_dumper_cli doctor"
+            f"  Diagnose: {CLI} doctor"
         )
     return candidate
 
@@ -89,7 +109,7 @@ def native_lib() -> Path:
     hint = (
         "  Fix: run scripts/setup.sh (or scripts/setup.ps1 on Windows),\n"
         "       or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`.\n"
-        f"  Diagnose: {PYCMD} -m j2c_dumper_cli doctor"
+        f"  Diagnose: {CLI} doctor"
     )
     if not libdir.exists():
         raise FileNotFoundError(
@@ -208,7 +228,7 @@ def _preflight_recover(run_cmd: Optional[str], no_dynamic: bool) -> None:
                       "artifacts are missing.")
         for p in problems:
             console.print(f"  - {p}")
-        console.print(f"Run [bold]{PYCMD} -m j2c_dumper_cli doctor[/] for a full "
+        console.print(f"Run [bold]{CLI} doctor[/] for a full "
                       "report, then [bold]scripts/setup.sh[/] "
                       "(or scripts/setup.ps1 on Windows).")
         raise typer.Exit(code=2)
@@ -332,7 +352,7 @@ def doctor() -> None:
                       "in place.")
         for c in report.warnings:
             console.print(f"[yellow]note:[/] {c.name}: {c.detail}")
-        console.print(f"Try: {PYCMD} -m j2c_dumper_cli recover IN.jar -o OUT.jar "
+        console.print(f"Try: {CLI} recover IN.jar -o OUT.jar "
                       "--run-cmd \"java -jar IN.jar\"")
     else:
         missing = ", ".join(c.name for c in report.blocking)

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -17,12 +17,17 @@ from rich.console import Console
 
 from j2c_dumper_cli import doctor as doctor_mod
 
-HELP = """\
+# The interpreter name setup selects and that is present on each platform:
+# a minimal POSIX environment ships `python3` (not `python`); Windows ships
+# `python`. Runtime messages echo the one that will actually work here.
+PYCMD = "python" if os.name == "nt" else "python3"
+
+HELP = f"""\
 Recover JNI-native transpiled JARs back to readable JVM bytecode.
 
 DEFAULT PATH (dynamic): if the JAR can be launched, run
 
-    python -m j2c_dumper_cli recover IN.jar -o OUT.jar --run-cmd "java -jar IN.jar"
+    {PYCMD} -m j2c_dumper_cli recover IN.jar -o OUT.jar --run-cmd "java -jar IN.jar"
 
 FIRST TIME? run `doctor` to check your toolchain, then `scripts/setup.sh`
 (or `scripts/setup.ps1` on Windows) to build everything.
@@ -34,10 +39,19 @@ individual stage commands and docs/getting-started.md.
 
 app = typer.Typer(
     add_completion=False,
-    no_args_is_help=True,
     help=HELP,
 )
 console = Console(stderr=True)
+
+
+@app.callback(invoke_without_command=True)
+def _root(ctx: typer.Context) -> None:
+    # Running with no subcommand prints help and exits 0 (a successful,
+    # intentional "show me what's here"), rather than Typer's default
+    # usage-error exit code.
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(code=0)
 
 
 # ------------------------------------------------------------------
@@ -63,7 +77,7 @@ def jvm_bin(name: str) -> Path:
             f"JVM module '{name}' is not built.\n"
             f"  Fix: run scripts/setup.sh (or scripts/setup.ps1 on Windows),\n"
             f"       or `cd jvm && ./gradlew :{name}:installDist`.\n"
-            f"  Diagnose: python -m j2c_dumper_cli doctor"
+            f"  Diagnose: {PYCMD} -m j2c_dumper_cli doctor"
         )
     return candidate
 
@@ -75,17 +89,21 @@ def native_lib() -> Path:
     hint = (
         "  Fix: run scripts/setup.sh (or scripts/setup.ps1 on Windows),\n"
         "       or `cd native && JDK_HOME=\"$JAVA_HOME\" bash build.sh`.\n"
-        "  Diagnose: python -m j2c_dumper_cli doctor"
+        f"  Diagnose: {PYCMD} -m j2c_dumper_cli doctor"
     )
     if not libdir.exists():
         raise FileNotFoundError(
             "Native JVMTI agent is not built (the dynamic path needs it).\n" + hint
         )
-    for name in ("j2c_agent.dll", "j2c_agent.so", "j2c_agent.dylib"):
-        if (libdir / name).exists():
-            return libdir / name
+    # Only the host-matching artifact can be loaded here; a leftover .so on
+    # Windows (or .dll on Linux) is not usable.
+    want = doctor_mod.host_agent_name()
+    target = libdir / want
+    if target.exists():
+        return target
     raise FileNotFoundError(
-        f"Native JVMTI agent is not built: no j2c_agent.* under {libdir}.\n" + hint
+        f"Native JVMTI agent is not built for this host: no {want} under {libdir}.\n"
+        + hint
     )
 
 
@@ -190,7 +208,7 @@ def _preflight_recover(run_cmd: Optional[str], no_dynamic: bool) -> None:
                       "artifacts are missing.")
         for p in problems:
             console.print(f"  - {p}")
-        console.print("Run [bold]python -m j2c_dumper_cli doctor[/] for a full "
+        console.print(f"Run [bold]{PYCMD} -m j2c_dumper_cli doctor[/] for a full "
                       "report, then [bold]scripts/setup.sh[/] "
                       "(or scripts/setup.ps1 on Windows).")
         raise typer.Exit(code=2)
@@ -305,8 +323,16 @@ def doctor() -> None:
             console.print(f"  - {tag}{c.name}: {c.fix}")
 
     if report.healthy:
-        console.print("\n[bold green]Ready.[/] Try: "
-                      "python -m j2c_dumper_cli recover IN.jar -o OUT.jar "
+        # These checks confirm the required tool versions and that the build
+        # artifacts the default path needs are present. They do not launch the
+        # JVM modules or load the agent, so this is a readiness of the inputs,
+        # not a guarantee that a given target recovers cleanly.
+        console.print("\n[bold green]Required checks passed.[/] "
+                      "Versions and build artifacts for the default path are "
+                      "in place.")
+        for c in report.warnings:
+            console.print(f"[yellow]note:[/] {c.name}: {c.detail}")
+        console.print(f"Try: {PYCMD} -m j2c_dumper_cli recover IN.jar -o OUT.jar "
                       "--run-cmd \"java -jar IN.jar\"")
     else:
         missing = ", ".join(c.name for c in report.blocking)

--- a/py/j2c_dumper_cli/pyproject.toml
+++ b/py/j2c_dumper_cli/pyproject.toml
@@ -2,7 +2,7 @@
 name = "j2c-dumper-cli"
 version = "0.1.0"
 description = "Top-level orchestrator for j2c-dumper"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "typer>=0.15.1",
     "rich>=13.7.0",

--- a/py/j2c_dumper_cli/tests/test_cli_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_cli_doctor.py
@@ -23,18 +23,33 @@ def _report(*checks):
 
 def test_doctor_exits_zero_when_healthy(monkeypatch):
     healthy = _report(
-        doctor_mod.Check("Java / JDK 21+", doctor_mod.STATUS_OK, "Java 21"),
+        doctor_mod.Check("Java / JDK 17+", doctor_mod.STATUS_OK, "Java 17"),
         doctor_mod.Check("Python 3.11+", doctor_mod.STATUS_OK, "3.12"),
     )
     monkeypatch.setattr(doctor_mod, "build_report", lambda root: healthy)
     result = runner.invoke(app, ["doctor"])
     assert result.exit_code == 0
-    assert "Ready" in result.output
+    assert "Required checks passed" in result.output
+
+
+def test_doctor_healthy_with_warning_exits_zero(monkeypatch):
+    # A WARN on a required check is a caveat, not a failure: still exit 0,
+    # and the caveat is surfaced as a note.
+    healthy = _report(
+        doctor_mod.Check("Java / JDK 17+", doctor_mod.STATUS_WARN,
+                         "Java 17 but JAVA_HOME is not set"),
+        doctor_mod.Check("Python 3.11+", doctor_mod.STATUS_OK, "3.12"),
+    )
+    monkeypatch.setattr(doctor_mod, "build_report", lambda root: healthy)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "Required checks passed" in result.output
+    assert "note:" in result.output
 
 
 def test_doctor_exits_nonzero_when_missing(monkeypatch):
     broken = _report(
-        doctor_mod.Check("Java / JDK 21+", doctor_mod.STATUS_OK, "Java 21"),
+        doctor_mod.Check("Java / JDK 17+", doctor_mod.STATUS_OK, "Java 17"),
         doctor_mod.Check(
             "Native JVMTI agent",
             doctor_mod.STATUS_MISSING,
@@ -47,3 +62,20 @@ def test_doctor_exits_nonzero_when_missing(monkeypatch):
     assert result.exit_code == 1
     assert "Not ready" in result.output
     assert "scripts/setup.sh" in result.output
+
+
+# ------------------------------------------------------------------
+# Entry-point exit codes (no-args help + top-level --help)
+# ------------------------------------------------------------------
+
+def test_no_args_prints_help_and_exits_zero():
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    # The default-path guidance from the group help is shown.
+    assert "recover" in result.output
+
+
+def test_top_level_help_exits_zero():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "recover" in result.output

--- a/py/j2c_dumper_cli/tests/test_cli_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_cli_doctor.py
@@ -1,0 +1,49 @@
+"""CLI-level checks for the `doctor` command (exit codes + rendering).
+
+Uses Typer's test runner with a mocked report, so it needs neither Ghidra
+nor a real toolchain build.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from j2c_dumper_cli import doctor as doctor_mod
+from j2c_dumper_cli.main import app
+
+runner = CliRunner()
+
+
+def _report(*checks):
+    r = doctor_mod.Report()
+    for c in checks:
+        r.add(c)
+    return r
+
+
+def test_doctor_exits_zero_when_healthy(monkeypatch):
+    healthy = _report(
+        doctor_mod.Check("Java / JDK 21+", doctor_mod.STATUS_OK, "Java 21"),
+        doctor_mod.Check("Python 3.11+", doctor_mod.STATUS_OK, "3.12"),
+    )
+    monkeypatch.setattr(doctor_mod, "build_report", lambda root: healthy)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "Ready" in result.output
+
+
+def test_doctor_exits_nonzero_when_missing(monkeypatch):
+    broken = _report(
+        doctor_mod.Check("Java / JDK 21+", doctor_mod.STATUS_OK, "Java 21"),
+        doctor_mod.Check(
+            "Native JVMTI agent",
+            doctor_mod.STATUS_MISSING,
+            "no j2c_agent.*",
+            fix="run scripts/setup.sh",
+        ),
+    )
+    monkeypatch.setattr(doctor_mod, "build_report", lambda root: broken)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "Not ready" in result.output
+    assert "scripts/setup.sh" in result.output

--- a/py/j2c_dumper_cli/tests/test_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_doctor.py
@@ -287,6 +287,18 @@ def test_build_report_not_ready_on_arm_with_arm_agent(tmp_path, arm_host,
     assert "Native JVMTI agent" in {c.name for c in report.blocking}
 
 
+def test_check_native_agent_rejects_foreign_arch_on_supported_host(tmp_path,
+                                                                   x86_host):
+    # Host-matching name, wrong machine code: the JVM here cannot load it.
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    _write_elf(libdir / "j2c_agent.so", _ELF_AARCH64)
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "arm64" in c.detail   # names what it was built for
+    assert "x86_64" in c.detail  # names this host
+
+
 def test_check_native_agent_ok_when_arch_matches(tmp_path, x86_host):
     libdir = tmp_path / "native" / "build" / "lib"
     libdir.mkdir(parents=True)

--- a/py/j2c_dumper_cli/tests/test_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_doctor.py
@@ -127,18 +127,51 @@ def test_check_jvm_modules_ok(tmp_path):
 # Native agent probe
 # ------------------------------------------------------------------
 
+def _write_agent(tmp_path, libname, size=doctor._MIN_AGENT_BYTES + 1):
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True, exist_ok=True)
+    (libdir / libname).write_bytes(b"\x7fELF" + b"\x00" * (size - 4))
+    return libdir
+
+
+def test_host_agent_name_per_platform():
+    assert doctor.host_agent_name("linux") == "j2c_agent.so"
+    assert doctor.host_agent_name("darwin") == "j2c_agent.dylib"
+    assert doctor.host_agent_name("win32") == "j2c_agent.dll"
+
+
 def test_check_native_agent_missing(tmp_path):
     c = doctor.check_native_agent(tmp_path)
     assert c.status == doctor.STATUS_MISSING
     assert c.fix
 
 
-@pytest.mark.parametrize("libname", ["j2c_agent.so", "j2c_agent.dll", "j2c_agent.dylib"])
-def test_check_native_agent_present(tmp_path, libname):
+def test_check_native_agent_present_host_match(tmp_path):
+    # The host-matching name (as this interpreter sees it) reads as ready.
+    _write_agent(tmp_path, doctor.host_agent_name())
+    assert doctor.check_native_agent(tmp_path).status == doctor.STATUS_OK
+
+
+def test_check_native_agent_rejects_wrong_platform(tmp_path, monkeypatch):
+    # Pretend we are on Linux; a leftover Windows DLL must not read as ready.
+    monkeypatch.setattr(doctor.sys, "platform", "linux")
+    monkeypatch.setattr(doctor.os, "name", "posix")
+    _write_agent(tmp_path, "j2c_agent.dll")
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "j2c_agent.so" in c.detail  # tells the user what this host needs
+    assert "j2c_agent.dll" in c.detail  # names the wrong-platform leftover
+
+
+def test_check_native_agent_rejects_empty_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor.sys, "platform", "linux")
+    monkeypatch.setattr(doctor.os, "name", "posix")
     libdir = tmp_path / "native" / "build" / "lib"
     libdir.mkdir(parents=True)
-    (libdir / libname).write_bytes(b"\x7fELF")
-    assert doctor.check_native_agent(tmp_path).status == doctor.STATUS_OK
+    (libdir / "j2c_agent.so").write_bytes(b"")  # 0 bytes → not a real library
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "empty" in c.detail or "truncated" in c.detail
 
 
 # ------------------------------------------------------------------
@@ -207,9 +240,59 @@ def test_build_report_healthy_when_everything_present(tmp_path, monkeypatch):
                         lambda exe: 'openjdk version "21.0.10"')
     monkeypatch.setattr(sys, "version_info", (3, 11, 5))
     _make_jvm_installs(tmp_path, doctor.REQUIRED_JVM_MODULES)
-    libdir = tmp_path / "native" / "build" / "lib"
-    libdir.mkdir(parents=True)
-    (libdir / "j2c_agent.so").write_bytes(b"\x7fELF")
+    _write_agent(tmp_path, doctor.host_agent_name())
     report = doctor.build_report(tmp_path)
     assert report.healthy
     assert report.blocking == []
+
+
+def test_warn_does_not_block():
+    # A required check that only WARNs is a caveat, not a blocker.
+    r = doctor.Report()
+    r.add(doctor.Check("Java / JDK 17+", doctor.STATUS_WARN, "no JAVA_HOME"))
+    r.add(doctor.Check("Python 3.11+", doctor.STATUS_OK, "3.12"))
+    assert r.healthy
+    assert r.blocking == []
+    assert [c.name for c in r.warnings] == ["Java / JDK 17+"]
+
+
+def test_build_report_warn_stays_healthy(tmp_path, monkeypatch):
+    # Java new enough but JAVA_HOME unset -> WARN, yet the report is healthy
+    # because the agent and modules are present.
+    monkeypatch.delenv("JAVA_HOME", raising=False)
+    monkeypatch.setattr(doctor, "_java_executable", lambda: "/usr/bin/java")
+    monkeypatch.setattr(doctor, "_query_java_version",
+                        lambda exe: 'openjdk version "17.0.9"')
+    monkeypatch.setattr(sys, "version_info", (3, 11, 5))
+    _make_jvm_installs(tmp_path, doctor.REQUIRED_JVM_MODULES)
+    _write_agent(tmp_path, doctor.host_agent_name())
+    report = doctor.build_report(tmp_path)
+    assert report.healthy
+    assert any(c.status == doctor.STATUS_WARN for c in report.warnings)
+
+
+# ------------------------------------------------------------------
+# Python recover-stage dependency probe
+# ------------------------------------------------------------------
+
+def test_check_python_recover_deps_ok():
+    # capstone + lief are installed in the test/setup environment.
+    c = doctor.check_python_recover_deps()
+    assert c.status == doctor.STATUS_OK
+    assert not c.optional
+
+
+def test_check_python_recover_deps_missing(monkeypatch):
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "binary_introspect.cli" or name.startswith("capstone"):
+            raise ModuleNotFoundError("No module named 'capstone'", name="capstone")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    c = doctor.check_python_recover_deps()
+    assert c.status == doctor.STATUS_MISSING
+    assert not c.optional
+    assert c.fix

--- a/py/j2c_dumper_cli/tests/test_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_doctor.py
@@ -1,0 +1,215 @@
+"""Tests for the `doctor` diagnostics.
+
+None of these need Ghidra, a JVM build, or the native agent: every probe is
+driven with mocked "present" / "missing" tool states.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from j2c_dumper_cli import doctor
+
+
+# ------------------------------------------------------------------
+# Java version parsing
+# ------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ('openjdk version "21.0.10" 2026-01-20', 21),
+        ('openjdk version "17.0.9" 2023-10-17', 17),
+        ('java version "1.8.0_202"', 8),
+        ('openjdk version "11.0.2" 2019-01-15', 11),
+        ("garbage without a version", None),
+    ],
+)
+def test_parse_java_major(text, expected):
+    assert doctor._parse_java_major(text) == expected
+
+
+# ------------------------------------------------------------------
+# Java probe
+# ------------------------------------------------------------------
+
+def test_check_java_missing(monkeypatch):
+    monkeypatch.delenv("JAVA_HOME", raising=False)
+    monkeypatch.setattr(doctor, "_java_executable", lambda: None)
+    c = doctor.check_java()
+    assert c.status == doctor.STATUS_MISSING
+    assert c.fix
+
+
+def test_check_java_too_old(monkeypatch):
+    monkeypatch.setenv("JAVA_HOME", "/opt/jdk8")
+    monkeypatch.setattr(doctor, "_java_executable", lambda: "/opt/jdk8/bin/java")
+    monkeypatch.setattr(doctor, "_query_java_version",
+                        lambda exe: 'openjdk version "1.8.0_202"')
+    c = doctor.check_java()
+    assert c.status == doctor.STATUS_MISSING
+    assert "8" in c.detail
+
+
+def test_check_java_ok(monkeypatch):
+    monkeypatch.setenv("JAVA_HOME", "/opt/jdk21")
+    monkeypatch.setattr(doctor, "_java_executable", lambda: "/opt/jdk21/bin/java")
+    monkeypatch.setattr(doctor, "_query_java_version",
+                        lambda exe: 'openjdk version "21.0.10" 2026-01-20')
+    c = doctor.check_java()
+    assert c.status == doctor.STATUS_OK
+    assert "21" in c.detail
+
+
+def test_check_java_ok_but_no_java_home(monkeypatch):
+    monkeypatch.delenv("JAVA_HOME", raising=False)
+    monkeypatch.setattr(doctor, "_java_executable", lambda: "/usr/bin/java")
+    monkeypatch.setattr(doctor, "_query_java_version",
+                        lambda exe: 'openjdk version "21.0.10" 2026-01-20')
+    c = doctor.check_java()
+    # 21 is fine but JAVA_HOME missing → warn (native build needs it).
+    assert c.status == doctor.STATUS_WARN
+    assert c.fix
+
+
+# ------------------------------------------------------------------
+# Python probe
+# ------------------------------------------------------------------
+
+def test_check_python_ok(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", (3, 11, 5))
+    assert doctor.check_python().status == doctor.STATUS_OK
+
+
+def test_check_python_too_old(monkeypatch):
+    monkeypatch.setattr(sys, "version_info", (3, 9, 18))
+    c = doctor.check_python()
+    assert c.status == doctor.STATUS_MISSING
+    assert c.fix
+
+
+# ------------------------------------------------------------------
+# JVM modules probe
+# ------------------------------------------------------------------
+
+def _make_jvm_installs(root: Path, modules) -> None:
+    suffix = ".bat" if os.name == "nt" else ""
+    for m in modules:
+        script = root / "jvm" / m / "build" / "install" / m / "bin" / f"{m}{suffix}"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("#!/bin/sh\n")
+
+
+def test_check_jvm_modules_missing(tmp_path):
+    c = doctor.check_jvm_modules(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "jar-parser" in c.detail
+
+
+def test_check_jvm_modules_partial(tmp_path):
+    _make_jvm_installs(tmp_path, ["jar-parser"])
+    c = doctor.check_jvm_modules(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "trace-to-bytecode" in c.detail
+    assert "jar-parser" not in c.detail
+
+
+def test_check_jvm_modules_ok(tmp_path):
+    _make_jvm_installs(tmp_path, doctor.REQUIRED_JVM_MODULES)
+    assert doctor.check_jvm_modules(tmp_path).status == doctor.STATUS_OK
+
+
+# ------------------------------------------------------------------
+# Native agent probe
+# ------------------------------------------------------------------
+
+def test_check_native_agent_missing(tmp_path):
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert c.fix
+
+
+@pytest.mark.parametrize("libname", ["j2c_agent.so", "j2c_agent.dll", "j2c_agent.dylib"])
+def test_check_native_agent_present(tmp_path, libname):
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    (libdir / libname).write_bytes(b"\x7fELF")
+    assert doctor.check_native_agent(tmp_path).status == doctor.STATUS_OK
+
+
+# ------------------------------------------------------------------
+# Optional tools
+# ------------------------------------------------------------------
+
+def test_check_ghidra_optional_when_absent(monkeypatch):
+    monkeypatch.delenv("GHIDRA_INSTALL_DIR", raising=False)
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    c = doctor.check_ghidra()
+    assert c.optional is True
+    assert c.status == doctor.STATUS_OPTIONAL
+
+
+def test_check_ghidra_present_via_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+    c = doctor.check_ghidra()
+    assert c.status == doctor.STATUS_OK
+    assert c.optional is True
+
+
+def test_check_zig_optional_when_absent(monkeypatch):
+    monkeypatch.delenv("ZIG", raising=False)
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    c = doctor.check_zig()
+    assert c.optional is True
+    assert c.status == doctor.STATUS_OPTIONAL
+
+
+def test_check_zig_present(monkeypatch):
+    monkeypatch.delenv("ZIG", raising=False)
+    monkeypatch.setattr(doctor.shutil, "which",
+                        lambda name: "/usr/bin/zig" if name == "zig" else None)
+    assert doctor.check_zig().status == doctor.STATUS_OK
+
+
+def test_check_unicorn_is_optional():
+    # Regardless of whether unicorn is installed, it must be marked optional.
+    c = doctor.check_unicorn()
+    assert c.optional is True
+    assert c.status in (doctor.STATUS_OK, doctor.STATUS_OPTIONAL)
+
+
+# ------------------------------------------------------------------
+# Aggregate report
+# ------------------------------------------------------------------
+
+def test_build_report_blocking_when_nothing_built(tmp_path, monkeypatch):
+    monkeypatch.delenv("JAVA_HOME", raising=False)
+    monkeypatch.setattr(doctor, "_java_executable", lambda: None)
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+    report = doctor.build_report(tmp_path)
+    assert not report.healthy
+    names = {c.name for c in report.blocking}
+    # Missing java, jvm modules and native agent are all blocking.
+    assert "JVM modules (installDist)" in names
+    assert "Native JVMTI agent" in names
+    # Optional tools never block.
+    assert all(not c.optional for c in report.blocking)
+
+
+def test_build_report_healthy_when_everything_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("JAVA_HOME", "/opt/jdk21")
+    monkeypatch.setattr(doctor, "_java_executable", lambda: "/opt/jdk21/bin/java")
+    monkeypatch.setattr(doctor, "_query_java_version",
+                        lambda exe: 'openjdk version "21.0.10"')
+    monkeypatch.setattr(sys, "version_info", (3, 11, 5))
+    _make_jvm_installs(tmp_path, doctor.REQUIRED_JVM_MODULES)
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    (libdir / "j2c_agent.so").write_bytes(b"\x7fELF")
+    report = doctor.build_report(tmp_path)
+    assert report.healthy
+    assert report.blocking == []

--- a/py/j2c_dumper_cli/tests/test_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_doctor.py
@@ -175,6 +175,64 @@ def test_check_native_agent_rejects_empty_file(tmp_path, monkeypatch):
 
 
 # ------------------------------------------------------------------
+# Architecture normalisation + agent-arch header reading
+# ------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("x86_64", "x86_64"), ("AMD64", "x86_64"), ("x64", "x86_64"),
+        ("aarch64", "arm64"), ("arm64", "arm64"),
+        ("i686", "x86"), ("armv7l", "arm"),
+    ],
+)
+def test_host_machine_normalises(raw, expected):
+    assert doctor.host_machine(raw) == expected
+
+
+def _write_elf(path: Path, e_machine: int, size=doctor._MIN_AGENT_BYTES + 1):
+    header = bytearray(size)
+    header[0:4] = b"\x7fELF"
+    header[4] = 2  # 64-bit
+    header[5] = 1  # little-endian
+    header[18:20] = e_machine.to_bytes(2, "little")
+    path.write_bytes(bytes(header))
+
+
+def test_agent_arch_reads_elf(tmp_path):
+    p = tmp_path / "lib.so"
+    _write_elf(p, 0x3E)  # x86-64
+    assert doctor.agent_arch(p) == "x86_64"
+    _write_elf(p, 0xB7)  # aarch64
+    assert doctor.agent_arch(p) == "arm64"
+
+
+def test_check_native_agent_rejects_wrong_arch(tmp_path, monkeypatch):
+    # A host-named agent whose machine code is x86-64 must not read as ready on
+    # an ARM host (native/build.sh only ever emits x86-64).
+    monkeypatch.setattr(doctor.sys, "platform", "linux")
+    monkeypatch.setattr(doctor.os, "name", "posix")
+    monkeypatch.setattr(doctor, "host_machine", lambda machine=None: "arm64")
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    _write_elf(libdir / "j2c_agent.so", 0x3E)  # built for x86-64
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "x86_64" in c.detail  # names what it was built for
+    assert "arm64" in c.detail   # names this host
+
+
+def test_check_native_agent_ok_when_arch_matches(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor.sys, "platform", "linux")
+    monkeypatch.setattr(doctor.os, "name", "posix")
+    monkeypatch.setattr(doctor, "host_machine", lambda machine=None: "x86_64")
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    _write_elf(libdir / "j2c_agent.so", 0x3E)
+    assert doctor.check_native_agent(tmp_path).status == doctor.STATUS_OK
+
+
+# ------------------------------------------------------------------
 # Optional tools
 # ------------------------------------------------------------------
 
@@ -296,3 +354,39 @@ def test_check_python_recover_deps_missing(monkeypatch):
     assert c.status == doctor.STATUS_MISSING
     assert not c.optional
     assert c.fix
+
+
+def _make_venv_python(root: Path) -> Path:
+    if os.name == "nt":
+        py = root / "py" / ".venv" / "Scripts" / "python.exe"
+    else:
+        py = root / "py" / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_text("")
+    return py
+
+
+def test_venv_python_detected(tmp_path):
+    assert doctor.venv_python(tmp_path) is None
+    made = _make_venv_python(tmp_path)
+    assert doctor.venv_python(tmp_path) == made
+
+
+def test_check_python_recover_deps_points_at_venv(tmp_path, monkeypatch):
+    # When the import fails but a uv venv exists (and is not the current
+    # interpreter), the fix must send the user to that interpreter/launcher
+    # rather than only suggesting a reinstall.
+    _make_venv_python(tmp_path)
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "binary_introspect.cli" or name.startswith("capstone"):
+            raise ModuleNotFoundError("No module named 'capstone'", name="capstone")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    c = doctor.check_python_recover_deps(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert "scripts/j2c" in c.fix or "j2c.ps1" in c.fix
+    assert ".venv" in c.fix

--- a/py/j2c_dumper_cli/tests/test_doctor.py
+++ b/py/j2c_dumper_cli/tests/test_doctor.py
@@ -127,11 +127,33 @@ def test_check_jvm_modules_ok(tmp_path):
 # Native agent probe
 # ------------------------------------------------------------------
 
-def _write_agent(tmp_path, libname, size=doctor._MIN_AGENT_BYTES + 1):
+_ELF_X86_64 = 0x3E
+_ELF_AARCH64 = 0xB7
+
+# e_machine value matching the architecture the agent build supports, so a
+# fixture agent written with it reads as ready on a supported host.
+_ELF_SUPPORTED = _ELF_X86_64
+
+
+def _write_agent(tmp_path, libname, size=doctor._MIN_AGENT_BYTES + 1,
+                 e_machine=_ELF_SUPPORTED):
     libdir = tmp_path / "native" / "build" / "lib"
     libdir.mkdir(parents=True, exist_ok=True)
-    (libdir / libname).write_bytes(b"\x7fELF" + b"\x00" * (size - 4))
+    _write_elf(libdir / libname, e_machine, size)
     return libdir
+
+
+@pytest.fixture
+def x86_host(monkeypatch):
+    """Pin the probes to a Linux x86-64 host, the one the build supports.
+
+    Without this the result would depend on the machine running the tests:
+    ``check_native_agent`` deliberately refuses to call any agent ready on a
+    CPU ``native/build.sh`` cannot build for.
+    """
+    monkeypatch.setattr(doctor.sys, "platform", "linux")
+    monkeypatch.setattr(doctor.os, "name", "posix")
+    monkeypatch.setattr(doctor, "host_machine", lambda machine=None: "x86_64")
 
 
 def test_host_agent_name_per_platform():
@@ -140,22 +162,20 @@ def test_host_agent_name_per_platform():
     assert doctor.host_agent_name("win32") == "j2c_agent.dll"
 
 
-def test_check_native_agent_missing(tmp_path):
+def test_check_native_agent_missing(tmp_path, x86_host):
     c = doctor.check_native_agent(tmp_path)
     assert c.status == doctor.STATUS_MISSING
     assert c.fix
 
 
-def test_check_native_agent_present_host_match(tmp_path):
-    # The host-matching name (as this interpreter sees it) reads as ready.
+def test_check_native_agent_present_host_match(tmp_path, x86_host):
+    # The host-matching name, built for this host's CPU, reads as ready.
     _write_agent(tmp_path, doctor.host_agent_name())
     assert doctor.check_native_agent(tmp_path).status == doctor.STATUS_OK
 
 
-def test_check_native_agent_rejects_wrong_platform(tmp_path, monkeypatch):
-    # Pretend we are on Linux; a leftover Windows DLL must not read as ready.
-    monkeypatch.setattr(doctor.sys, "platform", "linux")
-    monkeypatch.setattr(doctor.os, "name", "posix")
+def test_check_native_agent_rejects_wrong_platform(tmp_path, x86_host):
+    # A leftover Windows DLL on Linux must not read as ready.
     _write_agent(tmp_path, "j2c_agent.dll")
     c = doctor.check_native_agent(tmp_path)
     assert c.status == doctor.STATUS_MISSING
@@ -163,15 +183,25 @@ def test_check_native_agent_rejects_wrong_platform(tmp_path, monkeypatch):
     assert "j2c_agent.dll" in c.detail  # names the wrong-platform leftover
 
 
-def test_check_native_agent_rejects_empty_file(tmp_path, monkeypatch):
-    monkeypatch.setattr(doctor.sys, "platform", "linux")
-    monkeypatch.setattr(doctor.os, "name", "posix")
+def test_check_native_agent_rejects_empty_file(tmp_path, x86_host):
     libdir = tmp_path / "native" / "build" / "lib"
     libdir.mkdir(parents=True)
     (libdir / "j2c_agent.so").write_bytes(b"")  # 0 bytes → not a real library
     c = doctor.check_native_agent(tmp_path)
     assert c.status == doctor.STATUS_MISSING
     assert "empty" in c.detail or "truncated" in c.detail
+
+
+def test_check_native_agent_rejects_unreadable_format(tmp_path, x86_host):
+    # Big enough to pass the size gate, but not a shared library we can
+    # identify — that is not proof the JVM here can load it.
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    (libdir / "j2c_agent.so").write_bytes(b"not-a-library"
+                                          + b"\x00" * doctor._MIN_AGENT_BYTES)
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert c.fix
 
 
 # ------------------------------------------------------------------
@@ -201,35 +231,69 @@ def _write_elf(path: Path, e_machine: int, size=doctor._MIN_AGENT_BYTES + 1):
 
 def test_agent_arch_reads_elf(tmp_path):
     p = tmp_path / "lib.so"
-    _write_elf(p, 0x3E)  # x86-64
+    _write_elf(p, _ELF_X86_64)
     assert doctor.agent_arch(p) == "x86_64"
-    _write_elf(p, 0xB7)  # aarch64
+    _write_elf(p, _ELF_AARCH64)
     assert doctor.agent_arch(p) == "arm64"
 
 
-def test_check_native_agent_rejects_wrong_arch(tmp_path, monkeypatch):
-    # A host-named agent whose machine code is x86-64 must not read as ready on
-    # an ARM host (native/build.sh only ever emits x86-64).
+@pytest.fixture
+def arm_host(monkeypatch):
+    """Pin the probes to a Linux arm64 host — a CPU the build cannot target."""
     monkeypatch.setattr(doctor.sys, "platform", "linux")
     monkeypatch.setattr(doctor.os, "name", "posix")
     monkeypatch.setattr(doctor, "host_machine", lambda machine=None: "arm64")
+
+
+def test_check_native_agent_rejects_wrong_arch(tmp_path, arm_host):
+    # A host-named agent whose machine code is x86-64 must not read as ready on
+    # an ARM host (native/build.sh only ever emits x86-64).
     libdir = tmp_path / "native" / "build" / "lib"
     libdir.mkdir(parents=True)
-    _write_elf(libdir / "j2c_agent.so", 0x3E)  # built for x86-64
+    _write_elf(libdir / "j2c_agent.so", _ELF_X86_64)
     c = doctor.check_native_agent(tmp_path)
     assert c.status == doctor.STATUS_MISSING
-    assert "x86_64" in c.detail  # names what it was built for
+    assert "x86_64" in c.detail  # names what the build can produce
     assert "arm64" in c.detail   # names this host
 
 
-def test_check_native_agent_ok_when_arch_matches(tmp_path, monkeypatch):
-    monkeypatch.setattr(doctor.sys, "platform", "linux")
-    monkeypatch.setattr(doctor.os, "name", "posix")
-    monkeypatch.setattr(doctor, "host_machine", lambda machine=None: "x86_64")
+def test_check_native_agent_rejects_arm_agent_on_arm_host(tmp_path, arm_host):
+    # An arm64-labelled leftover with the host-matching *name* is still not
+    # proof of a usable agent: native/build.sh cannot produce one for arm64,
+    # so the dynamic path stays not-ready here.
     libdir = tmp_path / "native" / "build" / "lib"
     libdir.mkdir(parents=True)
-    _write_elf(libdir / "j2c_agent.so", 0x3E)
-    assert doctor.check_native_agent(tmp_path).status == doctor.STATUS_OK
+    _write_elf(libdir / "j2c_agent.so", _ELF_AARCH64)
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_MISSING
+    assert not c.optional
+    assert "arm64" in c.detail
+    assert c.fix
+
+
+def test_build_report_not_ready_on_arm_with_arm_agent(tmp_path, arm_host,
+                                                      monkeypatch):
+    # Everything else in place on an ARM host: required-ready must still be
+    # false, because the default path's agent cannot be built for this CPU.
+    monkeypatch.setenv("JAVA_HOME", "/opt/jdk21")
+    monkeypatch.setattr(doctor, "_java_executable", lambda: "/opt/jdk21/bin/java")
+    monkeypatch.setattr(doctor, "_query_java_version",
+                        lambda exe: 'openjdk version "21.0.10"')
+    monkeypatch.setattr(sys, "version_info", (3, 11, 5))
+    _make_jvm_installs(tmp_path, doctor.REQUIRED_JVM_MODULES)
+    _write_agent(tmp_path, "j2c_agent.so", e_machine=_ELF_AARCH64)
+    report = doctor.build_report(tmp_path)
+    assert not report.healthy
+    assert "Native JVMTI agent" in {c.name for c in report.blocking}
+
+
+def test_check_native_agent_ok_when_arch_matches(tmp_path, x86_host):
+    libdir = tmp_path / "native" / "build" / "lib"
+    libdir.mkdir(parents=True)
+    _write_elf(libdir / "j2c_agent.so", _ELF_X86_64)
+    c = doctor.check_native_agent(tmp_path)
+    assert c.status == doctor.STATUS_OK
+    assert "x86_64" in c.detail
 
 
 # ------------------------------------------------------------------
@@ -291,7 +355,8 @@ def test_build_report_blocking_when_nothing_built(tmp_path, monkeypatch):
     assert all(not c.optional for c in report.blocking)
 
 
-def test_build_report_healthy_when_everything_present(tmp_path, monkeypatch):
+def test_build_report_healthy_when_everything_present(tmp_path, x86_host,
+                                                      monkeypatch):
     monkeypatch.setenv("JAVA_HOME", "/opt/jdk21")
     monkeypatch.setattr(doctor, "_java_executable", lambda: "/opt/jdk21/bin/java")
     monkeypatch.setattr(doctor, "_query_java_version",
@@ -314,7 +379,7 @@ def test_warn_does_not_block():
     assert [c.name for c in r.warnings] == ["Java / JDK 17+"]
 
 
-def test_build_report_warn_stays_healthy(tmp_path, monkeypatch):
+def test_build_report_warn_stays_healthy(tmp_path, x86_host, monkeypatch):
     # Java new enough but JAVA_HOME unset -> WARN, yet the report is healthy
     # because the agent and modules are present.
     monkeypatch.delenv("JAVA_HOME", raising=False)

--- a/py/native_emulate/README.md
+++ b/py/native_emulate/README.md
@@ -25,22 +25,31 @@ So the same engine works across the family; only two things are
 platform-specific (and abstracted): the object format and the calling convention.
 
 ## Install
-```
-python -m pip install unicorn
+`unicorn` must land in the interpreter that runs the harness — the workspace
+venv `scripts/setup.sh` created at `py/.venv`. Run from the repo root:
+
+```bash
+(cd py && uv pip install unicorn)
 ```
 
 ## Commands
+The `scripts/j2c` launcher does not wrap this harness, so call it with the
+workspace interpreter directly: `py/.venv/bin/python`
+(`py\.venv\Scripts\python.exe` on Windows). If setup fell back to `pip`, use
+the interpreter it installed into instead. Paths below are relative to the repo
+root.
+
 ```bash
 # 1) recover every native method (name, sig, fnPtr) — entry points auto-discovered
-python j2c_emu.py recover lib.so|natives.dll
+py/.venv/bin/python py/native_emulate/j2c_emu.py recover lib.so|natives.dll
 #    discovery order: Java_* exports  ->  JNI_OnLoad emulation (mock JavaVM)
 #                     ->  --registrar 0x.. / --binary-json (j2cc regc dispatch)
 
 # 2) dump the decrypted string constants of a function (alphabet, secret, msgs)
-python j2c_emu.py strings natives.dll --fn 0x10a23e30
+py/.venv/bin/python py/native_emulate/j2c_emu.py strings natives.dll --fn 0x10a23e30
 
 # 3) oracle: call a recovered native method as a pure function
-python j2c_emu.py call natives.dll --fn 0x10a3fb10 \
+py/.venv/bin/python py/native_emulate/j2c_emu.py call natives.dll --fn 0x10a3fb10 \
        --arg-bytes "AAAABBBBCCCC" --static "v=@alphabet.txt"
 #    --arg-bytes  -> a byte[] arg ;  --arg-str -> a String arg
 #    --static field=value | field=@file  -> supply a static field (e.g. an

--- a/py/native_emulate/j2c_emu.py
+++ b/py/native_emulate/j2c_emu.py
@@ -17,7 +17,8 @@ Generality: rests on the JVM-fixed JNI ABI, not on any obfuscator's choices.
 Backends: x86-64  PE/Win64  and  ELF/System-V.  (Unicorn supports more arches;
 add an ABI/Fmt pair to extend.)
 
-Requires: unicorn   (pip install unicorn)
+Requires: unicorn, in the interpreter that runs this script
+          ((cd py && uv pip install unicorn) for the workspace venv).
 """
 import argparse, json, re, struct, sys
 
@@ -25,7 +26,12 @@ try:
     from unicorn import *
     from unicorn.x86_const import *
 except ImportError:
-    sys.exit("need unicorn:  python -m pip install unicorn")
+    # Name the interpreter: unicorn has to land in the one running this script,
+    # not in whichever `pip` happens to be on PATH.
+    sys.exit(
+        "need unicorn:  (cd py && uv pip install unicorn)"
+        f"   or:  {sys.executable} -m pip install unicorn"
+    )
 
 NUL = bytes([0])
 

--- a/scripts/j2c
+++ b/scripts/j2c
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Single entry point for the j2c-dumper CLI.
+#
+# `scripts/setup.sh` syncs the Python workspace with `uv`, which installs the
+# packages into `py/.venv` — a *system* `python3 -m j2c_dumper_cli` cannot see
+# them. This launcher always runs the interpreter that has the packages: the
+# uv-managed venv when it exists, otherwise `$PYTHON` / `python3` (the pip
+# fallback installs into that interpreter's own environment).
+#
+#   scripts/j2c doctor
+#   scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VENV_PY="$ROOT/py/.venv/bin/python"
+if [ -x "$VENV_PY" ]; then
+    PY="$VENV_PY"
+else
+    PY="${PYTHON:-python3}"
+fi
+
+# Let the CLI echo this launcher (not a bare `python3 -m ...`) in its own hints,
+# so every printed follow-up command is one that actually works here.
+export J2C_CMD="scripts/j2c"
+
+exec "$PY" -m j2c_dumper_cli "$@"

--- a/scripts/j2c.ps1
+++ b/scripts/j2c.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+  Single entry point for the j2c-dumper CLI on Windows.
+
+.DESCRIPTION
+  scripts/setup.ps1 syncs the Python workspace with uv, which installs the
+  packages into py/.venv — a system `python -m j2c_dumper_cli` cannot see them.
+  This launcher always runs the interpreter that has the packages: the
+  uv-managed venv when it exists, otherwise $env:PYTHON / python (the pip
+  fallback installs into that interpreter's own environment).
+
+    scripts\j2c.ps1 doctor
+    scripts\j2c.ps1 recover in.jar -o out.jar --run-cmd "java -jar in.jar"
+#>
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Root = (Resolve-Path (Join-Path $ScriptDir "..")).Path
+
+$venvPy = Join-Path $Root "py/.venv/Scripts/python.exe"
+if (Test-Path $venvPy) {
+    $py = $venvPy
+} elseif ($env:PYTHON) {
+    $py = $env:PYTHON
+} else {
+    $py = "python"
+}
+
+# Let the CLI echo this launcher in its own hints, so every printed follow-up
+# command is one that actually works here.
+$env:J2C_CMD = "scripts\j2c.ps1"
+
+& $py -m j2c_dumper_cli @args
+exit $LASTEXITCODE

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -34,7 +34,7 @@ function Die($msg)  { Write-Host "error: $msg" -ForegroundColor Red; exit 1 }
 # Preconditions
 # ------------------------------------------------------------------
 if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
-    Die "java not found. Install a JDK 21+ (Temurin/Adoptium) and set JAVA_HOME, then re-run."
+    Die "java not found. Install a JDK 17+ (Temurin/Adoptium) and set JAVA_HOME, then re-run."
 }
 
 # ------------------------------------------------------------------
@@ -75,8 +75,11 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
 # ------------------------------------------------------------------
 # 3. Native JVMTI agent (dynamic path)
 # ------------------------------------------------------------------
+$nativeReady = $false
+$nativeNote = "the dynamic path was not set up"
 if ($SkipNative) {
     Warn "Skipping native agent build (-SkipNative). The dynamic path needs it."
+    $nativeNote = "native agent skipped (-SkipNative); the dynamic path is unavailable"
 } else {
     $jdkHome = if ($env:JDK_HOME) { $env:JDK_HOME } elseif ($env:JAVA_HOME) { $env:JAVA_HOME } else { "" }
     if (-not $jdkHome) {
@@ -84,32 +87,60 @@ if ($SkipNative) {
         $jdkHome = Split-Path -Parent (Split-Path -Parent $javaCmd)
     }
     $libDir = Join-Path $Root "native/build/lib"
-    $haveLib = (Test-Path (Join-Path $libDir "j2c_agent.dll")) -or `
-               (Test-Path (Join-Path $libDir "j2c_agent.so"))  -or `
-               (Test-Path (Join-Path $libDir "j2c_agent.dylib"))
+    # On Windows only j2c_agent.dll is loadable; a leftover .so/.dylib is a
+    # wrong-platform artifact and must not count as "already built".
+    $agent = Join-Path $libDir "j2c_agent.dll"
+    # Rebuild when the DLL is missing, empty, or older than any input.
+    $needsBuild = $true
+    if ((Test-Path $agent) -and ((Get-Item $agent).Length -gt 0)) {
+        $agentTime = (Get-Item $agent).LastWriteTimeUtc
+        $inputs = @()
+        $inputs += Get-ChildItem (Join-Path $Root "native/src") -File -ErrorAction SilentlyContinue
+        $inputs += Get-ChildItem (Join-Path $Root "native/include") -File -Recurse -ErrorAction SilentlyContinue
+        $buildScript = Join-Path $Root "native/build.sh"
+        if (Test-Path $buildScript) { $inputs += Get-Item $buildScript }
+        $newer = $inputs | Where-Object { $_.LastWriteTimeUtc -gt $agentTime }
+        if (-not $newer) { $needsBuild = $false }
+    }
     $hasZig = (Get-Command zig -ErrorAction SilentlyContinue) -or $env:ZIG
-    if ($haveLib -and -not $Force) {
-        Info "Native agent already built ($libDir); pass -Force to rebuild."
+    # The build is driven by native/build.sh, so a POSIX-style shell is required.
+    # Git Bash (from Git for Windows) runs it as a Windows toolchain and produces
+    # the Windows DLL. WSL runs it as Linux: it selects a Linux target and emits a
+    # .so, not the Windows .dll the JVM here loads, so it is NOT equivalent.
+    $hasBash = Get-Command bash -ErrorAction SilentlyContinue
+    if ((-not $needsBuild) -and (-not $Force)) {
+        Info "Native agent up to date ($agent); pass -Force to rebuild."
+        $nativeReady = $true
     } elseif (-not (Test-Path (Join-Path $jdkHome "include"))) {
         Warn "No JDK headers under '$jdkHome/include'; skipping native agent."
         Warn "Install a full JDK (not just a JRE), set JAVA_HOME, then re-run."
+        $nativeNote = "native agent skipped (no JDK headers); the dynamic path is unavailable"
     } elseif (-not $hasZig) {
         Warn "zig not found; skipping native agent (needed only for the dynamic path)."
         Warn "Install zig 0.16.x or set ZIG, then re-run. Emulation path needs no native build."
+        $nativeNote = "native agent skipped (zig not found); the dynamic path is unavailable"
+    } elseif (-not $hasBash) {
+        Warn "Git Bash not found; the native DLL build needs it (it runs native/build.sh)."
+        Warn "Install Git for Windows (provides Git Bash) so 'bash' is on PATH, then re-run."
+        Warn "Do NOT use WSL for this: WSL builds a Linux .so, not the Windows .dll the JVM here loads."
+        $nativeNote = "native agent skipped (Git Bash not found); the dynamic path is unavailable"
     } else {
         Info "Building native JVMTI agent (JDK_HOME=$jdkHome)"
-        if (-not (Get-Command bash -ErrorAction SilentlyContinue)) {
-            Warn "bash not found; run native/build.sh under Git Bash / WSL to build the agent."
-        } else {
-            Push-Location (Join-Path $Root "native")
-            try {
-                $env:JDK_HOME = $jdkHome
-                if (-not $env:ZIG) { $env:ZIG = "zig" }
-                bash build.sh
-                if ($LASTEXITCODE -ne 0) { Die "Native agent build failed. See the output above." }
-            } finally { Pop-Location }
-        }
+        Push-Location (Join-Path $Root "native")
+        try {
+            $env:JDK_HOME = $jdkHome
+            if (-not $env:ZIG) { $env:ZIG = "zig" }
+            bash build.sh
+            if ($LASTEXITCODE -ne 0) { Die "Native agent build failed. See the output above." }
+            $nativeReady = $true
+        } finally { Pop-Location }
     }
 }
 
-Info "Setup finished. Verify with: python -m j2c_dumper_cli doctor"
+if ($nativeReady) {
+    Info "Setup finished (default dynamic path ready). Verify with: python -m j2c_dumper_cli doctor"
+} else {
+    Warn "Setup finished, but $nativeNote."
+    Warn "Use the emulation fallback, or install the missing piece and re-run."
+    Info "Verify with: python -m j2c_dumper_cli doctor"
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -7,7 +7,9 @@
   2. Sync the Python workspace (uv, or pip fallback)
   3. Build the native JVMTI agent when a JDK is available
 
-  Re-running is safe. On success, run:  python -m j2c_dumper_cli doctor
+  Re-running is safe. uv installs the Python workspace into py/.venv, so use the
+  scripts\j2c.ps1 launcher (which selects that interpreter) rather than a bare
+  `python -m j2c_dumper_cli`. On success, run:  scripts\j2c.ps1 doctor
 
 .PARAMETER Force
   Rebuild the native agent even if it is already up to date.
@@ -90,6 +92,11 @@ if ($SkipNative) {
     # On Windows only j2c_agent.dll is loadable; a leftover .so/.dylib is a
     # wrong-platform artifact and must not count as "already built".
     $agent = Join-Path $libDir "j2c_agent.dll"
+    # native/build.sh cross-targets x86-64 only; on an ARM64 Windows host it
+    # would emit a DLL the JVM here cannot load, so do not build it and do not
+    # report the default dynamic path as ready.
+    $hostArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+    $archOk = ($hostArch -eq "AMD64")
     # Rebuild when the DLL is missing, empty, or older than any input.
     $needsBuild = $true
     if ((Test-Path $agent) -and ((Get-Item $agent).Length -gt 0)) {
@@ -108,7 +115,12 @@ if ($SkipNative) {
     # the Windows DLL. WSL runs it as Linux: it selects a Linux target and emits a
     # .so, not the Windows .dll the JVM here loads, so it is NOT equivalent.
     $hasBash = Get-Command bash -ErrorAction SilentlyContinue
-    if ((-not $needsBuild) -and (-not $Force)) {
+    if (-not $archOk) {
+        Warn "This host is $hostArch, but native/build.sh targets x86-64; skipping native agent."
+        Warn "The default dynamic path needs a host-matching agent. Use the emulation fallback,"
+        Warn "or port native/build.sh to $hostArch and rebuild."
+        $nativeNote = "native agent skipped ($hostArch host; build.sh targets x86-64); the dynamic path is unavailable"
+    } elseif ((-not $needsBuild) -and (-not $Force)) {
         Info "Native agent up to date ($agent); pass -Force to rebuild."
         $nativeReady = $true
     } elseif (-not (Test-Path (Join-Path $jdkHome "include"))) {
@@ -138,9 +150,10 @@ if ($SkipNative) {
 }
 
 if ($nativeReady) {
-    Info "Setup finished (default dynamic path ready). Verify with: python -m j2c_dumper_cli doctor"
+    Info "Setup finished: required versions and build artifacts for the default (dynamic) path are in place."
+    Info "Recovery is still best-effort per target — inspect the output. Verify the toolchain with: scripts\j2c.ps1 doctor"
 } else {
     Warn "Setup finished, but $nativeNote."
     Warn "Use the emulation fallback, or install the missing piece and re-run."
-    Info "Verify with: python -m j2c_dumper_cli doctor"
+    Info "Verify with: scripts\j2c.ps1 doctor"
 }

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+  Idempotent one-shot setup for the default (dynamic) recovery path on Windows.
+
+.DESCRIPTION
+  1. Build the JVM modules (Gradle installDist)
+  2. Sync the Python workspace (uv, or pip fallback)
+  3. Build the native JVMTI agent when a JDK is available
+
+  Re-running is safe. On success, run:  python -m j2c_dumper_cli doctor
+
+.PARAMETER Force
+  Rebuild the native agent even if it is already up to date.
+
+.PARAMETER SkipNative
+  Build JVM + Python only. The dynamic path still needs the native agent.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Force,
+    [switch]$SkipNative
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Root = (Resolve-Path (Join-Path $ScriptDir "..")).Path
+
+function Info($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Warn($msg) { Write-Host "warn: $msg" -ForegroundColor Yellow }
+function Die($msg)  { Write-Host "error: $msg" -ForegroundColor Red; exit 1 }
+
+# ------------------------------------------------------------------
+# Preconditions
+# ------------------------------------------------------------------
+if (-not (Get-Command java -ErrorAction SilentlyContinue)) {
+    Die "java not found. Install a JDK 21+ (Temurin/Adoptium) and set JAVA_HOME, then re-run."
+}
+
+# ------------------------------------------------------------------
+# 1. JVM modules
+# ------------------------------------------------------------------
+Info "Building JVM modules (installDist)"
+$gradlew = Join-Path $Root "jvm/gradlew.bat"
+if (-not (Test-Path $gradlew)) { Die "jvm/gradlew.bat is missing." }
+Push-Location (Join-Path $Root "jvm")
+try {
+    & $gradlew installDist --no-daemon
+    if ($LASTEXITCODE -ne 0) { Die "Gradle build failed. See the output above." }
+} finally { Pop-Location }
+
+# ------------------------------------------------------------------
+# 2. Python workspace
+# ------------------------------------------------------------------
+Info "Syncing Python workspace"
+if (Get-Command uv -ErrorAction SilentlyContinue) {
+    Push-Location (Join-Path $Root "py")
+    try {
+        uv sync --all-packages
+        if ($LASTEXITCODE -ne 0) { Die "uv sync failed. See the output above." }
+    } finally { Pop-Location }
+} else {
+    Warn "uv not found; falling back to 'pip install -e' for each package."
+    $python = if ($env:PYTHON) { $env:PYTHON } else { "python" }
+    if (-not (Get-Command $python -ErrorAction SilentlyContinue)) { Die "python not found." }
+    & $python -m pip install `
+        -e (Join-Path $Root "py/j2c_dumper_cli") `
+        -e (Join-Path $Root "py/binary_introspect") `
+        -e (Join-Path $Root "py/manifest_merge") `
+        -e (Join-Path $Root "py/ast_matcher") `
+        -e (Join-Path $Root "py/snippet_importer")
+    if ($LASTEXITCODE -ne 0) { Die "pip install failed. Install uv (https://docs.astral.sh/uv/) and re-run." }
+}
+
+# ------------------------------------------------------------------
+# 3. Native JVMTI agent (dynamic path)
+# ------------------------------------------------------------------
+if ($SkipNative) {
+    Warn "Skipping native agent build (-SkipNative). The dynamic path needs it."
+} else {
+    $jdkHome = if ($env:JDK_HOME) { $env:JDK_HOME } elseif ($env:JAVA_HOME) { $env:JAVA_HOME } else { "" }
+    if (-not $jdkHome) {
+        $javaCmd = (Get-Command java).Source
+        $jdkHome = Split-Path -Parent (Split-Path -Parent $javaCmd)
+    }
+    $libDir = Join-Path $Root "native/build/lib"
+    $haveLib = (Test-Path (Join-Path $libDir "j2c_agent.dll")) -or `
+               (Test-Path (Join-Path $libDir "j2c_agent.so"))  -or `
+               (Test-Path (Join-Path $libDir "j2c_agent.dylib"))
+    $hasZig = (Get-Command zig -ErrorAction SilentlyContinue) -or $env:ZIG
+    if ($haveLib -and -not $Force) {
+        Info "Native agent already built ($libDir); pass -Force to rebuild."
+    } elseif (-not (Test-Path (Join-Path $jdkHome "include"))) {
+        Warn "No JDK headers under '$jdkHome/include'; skipping native agent."
+        Warn "Install a full JDK (not just a JRE), set JAVA_HOME, then re-run."
+    } elseif (-not $hasZig) {
+        Warn "zig not found; skipping native agent (needed only for the dynamic path)."
+        Warn "Install zig 0.16.x or set ZIG, then re-run. Emulation path needs no native build."
+    } else {
+        Info "Building native JVMTI agent (JDK_HOME=$jdkHome)"
+        if (-not (Get-Command bash -ErrorAction SilentlyContinue)) {
+            Warn "bash not found; run native/build.sh under Git Bash / WSL to build the agent."
+        } else {
+            Push-Location (Join-Path $Root "native")
+            try {
+                $env:JDK_HOME = $jdkHome
+                if (-not $env:ZIG) { $env:ZIG = "zig" }
+                bash build.sh
+                if ($LASTEXITCODE -ne 0) { Die "Native agent build failed. See the output above." }
+            } finally { Pop-Location }
+        }
+    }
+}
+
+Info "Setup finished. Verify with: python -m j2c_dumper_cli doctor"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Idempotent one-shot setup for the default (dynamic) recovery path.
+#
+#   1. Build the JVM modules (Gradle installDist)
+#   2. Sync the Python workspace (uv)
+#   3. Build the native JVMTI agent when a JDK is available
+#
+# Re-running is safe: Gradle and uv skip up-to-date work, and the native
+# agent is only rebuilt when its inputs changed (or --force is passed).
+#
+# On success, run:  python -m j2c_dumper_cli doctor
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FORCE=0
+SKIP_NATIVE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        --skip-native) SKIP_NATIVE=1 ;;
+        -h|--help)
+            echo "usage: scripts/setup.sh [--force] [--skip-native]"
+            echo "  --force        rebuild the native agent even if up to date"
+            echo "  --skip-native  build JVM + Python only (dynamic path needs native)"
+            exit 0
+            ;;
+        *) echo "unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+info() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mwarn:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ------------------------------------------------------------------
+# Preconditions
+# ------------------------------------------------------------------
+command -v java >/dev/null 2>&1 || die \
+    "java not found. Install a JDK 21+ (Temurin/Adoptium) and set JAVA_HOME, then re-run."
+
+# ------------------------------------------------------------------
+# 1. JVM modules
+# ------------------------------------------------------------------
+info "Building JVM modules (installDist)"
+if [ ! -f "$ROOT/jvm/gradlew" ]; then
+    die "jvm/gradlew is missing."
+fi
+# Invoke through `sh` so a missing exec bit (common after a plain checkout)
+# does not block the build.
+( cd "$ROOT/jvm" && sh ./gradlew installDist --no-daemon ) \
+    || die "Gradle build failed. See the output above."
+
+# ------------------------------------------------------------------
+# 2. Python workspace
+# ------------------------------------------------------------------
+info "Syncing Python workspace"
+if command -v uv >/dev/null 2>&1; then
+    ( cd "$ROOT/py" && uv sync --all-packages ) \
+        || die "uv sync failed. See the output above."
+else
+    warn "uv not found; falling back to 'pip install -e' for each package."
+    PYTHON="${PYTHON:-python3}"
+    command -v "$PYTHON" >/dev/null 2>&1 || die "python3 not found."
+    "$PYTHON" -m pip install -e "$ROOT/py/j2c_dumper_cli" \
+        -e "$ROOT/py/binary_introspect" \
+        -e "$ROOT/py/manifest_merge" \
+        -e "$ROOT/py/ast_matcher" \
+        -e "$ROOT/py/snippet_importer" \
+        || die "pip install failed. Install uv (https://docs.astral.sh/uv/) and re-run."
+fi
+
+# ------------------------------------------------------------------
+# 3. Native JVMTI agent (dynamic path)
+# ------------------------------------------------------------------
+if [ "$SKIP_NATIVE" -eq 1 ]; then
+    warn "Skipping native agent build (--skip-native). The dynamic path needs it."
+else
+    JDK_HOME="${JDK_HOME:-${JAVA_HOME:-}}"
+    if [ -z "$JDK_HOME" ]; then
+        # Derive JAVA_HOME from the java on PATH if possible.
+        JAVA_BIN="$(command -v java)"
+        JAVA_REAL="$(readlink -f "$JAVA_BIN" 2>/dev/null || echo "$JAVA_BIN")"
+        JDK_HOME="$(dirname "$(dirname "$JAVA_REAL")")"
+    fi
+    LIBDIR="$ROOT/native/build/lib"
+    have_lib=0
+    for name in j2c_agent.so j2c_agent.dylib j2c_agent.dll; do
+        [ -f "$LIBDIR/$name" ] && have_lib=1
+    done
+    if [ "$have_lib" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
+        info "Native agent already built ($LIBDIR); pass --force to rebuild."
+    elif [ ! -d "$JDK_HOME/include" ]; then
+        warn "No JDK headers under '$JDK_HOME/include'; skipping native agent."
+        warn "Install a full JDK (not just a JRE), set JAVA_HOME, then re-run."
+    elif ! command -v zig >/dev/null 2>&1 && [ -z "${ZIG:-}" ]; then
+        warn "zig not found; skipping native agent (needed only for the dynamic path)."
+        warn "Install zig 0.16.x or set ZIG, then re-run. Emulation path needs no native build."
+    else
+        info "Building native JVMTI agent (JDK_HOME=$JDK_HOME)"
+        ( cd "$ROOT/native" && JDK_HOME="$JDK_HOME" ZIG="${ZIG:-zig}" bash build.sh ) \
+            || die "Native agent build failed. See the output above."
+    fi
+fi
+
+info "Setup finished. Verify with: python -m j2c_dumper_cli doctor"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,9 @@
 # Re-running is safe: Gradle and uv skip up-to-date work, and the native
 # agent is only rebuilt when its inputs changed (or --force is passed).
 #
-# On success, run:  python3 -m j2c_dumper_cli doctor
+# uv installs the Python workspace into py/.venv, so use the scripts/j2c
+# launcher (which selects that interpreter) rather than a bare
+# `python3 -m j2c_dumper_cli`. On success, run:  scripts/j2c doctor
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -98,45 +100,54 @@ else
         *)                   AGENT_NAME="j2c_agent.so" ;;
     esac
     HOST_ARCH="$(uname -m)"
-    case "$HOST_ARCH" in
-        x86_64|amd64) : ;;
-        *) warn "native/build.sh targets x86-64 but this host is $HOST_ARCH; the agent may not load. " \
-                "Rebuild for $HOST_ARCH if the dynamic path fails to attach." ;;
-    esac
     AGENT="$LIBDIR/$AGENT_NAME"
-    # Rebuild when the artifact is missing, empty, or older than any input.
-    needs_build=0
-    if [ ! -s "$AGENT" ]; then
-        needs_build=1
-    else
-        for src in "$ROOT"/native/src/*.cpp "$ROOT"/native/include/* "$ROOT/native/build.sh"; do
-            [ -e "$src" ] || continue
-            if [ "$src" -nt "$AGENT" ]; then needs_build=1; break; fi
-        done
-    fi
-    if [ "$needs_build" -eq 0 ] && [ "$FORCE" -eq 0 ]; then
-        info "Native agent up to date ($AGENT); pass --force to rebuild."
-        NATIVE_READY=1
-    elif [ ! -d "$JDK_HOME/include" ]; then
-        warn "No JDK headers under '$JDK_HOME/include'; skipping native agent."
-        warn "Install a full JDK (not just a JRE), set JAVA_HOME, then re-run."
-        NATIVE_NOTE="native agent skipped (no JDK headers); the dynamic path is unavailable"
-    elif ! command -v zig >/dev/null 2>&1 && [ -z "${ZIG:-}" ]; then
-        warn "zig not found; skipping native agent (needed only for the dynamic path)."
-        warn "Install zig 0.16.x or set ZIG, then re-run. Emulation path needs no native build."
-        NATIVE_NOTE="native agent skipped (zig not found); the dynamic path is unavailable"
-    else
-        info "Building native JVMTI agent (JDK_HOME=$JDK_HOME)"
-        ( cd "$ROOT/native" && JDK_HOME="$JDK_HOME" ZIG="${ZIG:-zig}" bash build.sh ) \
-            || die "Native agent build failed. See the output above."
-        NATIVE_READY=1
-    fi
+    case "$HOST_ARCH" in
+        x86_64|amd64)
+            # Rebuild when the artifact is missing, empty, or older than any input.
+            needs_build=0
+            if [ ! -s "$AGENT" ]; then
+                needs_build=1
+            else
+                for src in "$ROOT"/native/src/*.cpp "$ROOT"/native/include/* "$ROOT/native/build.sh"; do
+                    [ -e "$src" ] || continue
+                    if [ "$src" -nt "$AGENT" ]; then needs_build=1; break; fi
+                done
+            fi
+            if [ "$needs_build" -eq 0 ] && [ "$FORCE" -eq 0 ]; then
+                info "Native agent up to date ($AGENT); pass --force to rebuild."
+                NATIVE_READY=1
+            elif [ ! -d "$JDK_HOME/include" ]; then
+                warn "No JDK headers under '$JDK_HOME/include'; skipping native agent."
+                warn "Install a full JDK (not just a JRE), set JAVA_HOME, then re-run."
+                NATIVE_NOTE="native agent skipped (no JDK headers); the dynamic path is unavailable"
+            elif ! command -v zig >/dev/null 2>&1 && [ -z "${ZIG:-}" ]; then
+                warn "zig not found; skipping native agent (needed only for the dynamic path)."
+                warn "Install zig 0.16.x or set ZIG, then re-run. Emulation path needs no native build."
+                NATIVE_NOTE="native agent skipped (zig not found); the dynamic path is unavailable"
+            else
+                info "Building native JVMTI agent (JDK_HOME=$JDK_HOME)"
+                ( cd "$ROOT/native" && JDK_HOME="$JDK_HOME" ZIG="${ZIG:-zig}" bash build.sh ) \
+                    || die "Native agent build failed. See the output above."
+                NATIVE_READY=1
+            fi
+            ;;
+        *)
+            # native/build.sh cross-targets x86-64 unconditionally; on any other
+            # host CPU it would emit an agent this JVM cannot load. Do not build
+            # it and do not report the default dynamic path as ready.
+            warn "This host is $HOST_ARCH, but native/build.sh targets x86-64; skipping native agent."
+            warn "The default dynamic path needs a host-matching agent. Use the emulation fallback,"
+            warn "or port native/build.sh to $HOST_ARCH and rebuild."
+            NATIVE_NOTE="native agent skipped ($HOST_ARCH host; build.sh targets x86-64); the dynamic path is unavailable"
+            ;;
+    esac
 fi
 
 if [ "$NATIVE_READY" -eq 1 ]; then
-    info "Setup finished (default dynamic path ready). Verify with: python3 -m j2c_dumper_cli doctor"
+    info "Setup finished: required versions and build artifacts for the default (dynamic) path are in place."
+    info "Recovery is still best-effort per target — inspect the output. Verify the toolchain with: scripts/j2c doctor"
 else
     warn "Setup finished, but $NATIVE_NOTE."
     warn "Use the emulation fallback, or install the missing piece and re-run."
-    info "Verify with: python3 -m j2c_dumper_cli doctor"
+    info "Verify with: scripts/j2c doctor"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@
 # Re-running is safe: Gradle and uv skip up-to-date work, and the native
 # agent is only rebuilt when its inputs changed (or --force is passed).
 #
-# On success, run:  python -m j2c_dumper_cli doctor
+# On success, run:  python3 -m j2c_dumper_cli doctor
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,7 +38,7 @@ die()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 # Preconditions
 # ------------------------------------------------------------------
 command -v java >/dev/null 2>&1 || die \
-    "java not found. Install a JDK 21+ (Temurin/Adoptium) and set JAVA_HOME, then re-run."
+    "java not found. Install a JDK 17+ (Temurin/Adoptium) and set JAVA_HOME, then re-run."
 
 # ------------------------------------------------------------------
 # 1. JVM modules
@@ -74,8 +74,11 @@ fi
 # ------------------------------------------------------------------
 # 3. Native JVMTI agent (dynamic path)
 # ------------------------------------------------------------------
+NATIVE_READY=0
+NATIVE_NOTE="the dynamic path was not set up"
 if [ "$SKIP_NATIVE" -eq 1 ]; then
     warn "Skipping native agent build (--skip-native). The dynamic path needs it."
+    NATIVE_NOTE="native agent skipped (--skip-native); the dynamic path is unavailable"
 else
     JDK_HOME="${JDK_HOME:-${JAVA_HOME:-}}"
     if [ -z "$JDK_HOME" ]; then
@@ -85,23 +88,55 @@ else
         JDK_HOME="$(dirname "$(dirname "$JAVA_REAL")")"
     fi
     LIBDIR="$ROOT/native/build/lib"
-    have_lib=0
-    for name in j2c_agent.so j2c_agent.dylib j2c_agent.dll; do
-        [ -f "$LIBDIR/$name" ] && have_lib=1
-    done
-    if [ "$have_lib" -eq 1 ] && [ "$FORCE" -eq 0 ]; then
-        info "Native agent already built ($LIBDIR); pass --force to rebuild."
+    # Only the host-matching artifact is usable; a leftover build for another
+    # OS must not be treated as ready. native/build.sh currently targets
+    # x86-64, so the produced agent is x86-64 for this OS.
+    case "$(uname -s)" in
+        Linux)               AGENT_NAME="j2c_agent.so" ;;
+        Darwin)              AGENT_NAME="j2c_agent.dylib" ;;
+        MINGW*|MSYS*|CYGWIN*) AGENT_NAME="j2c_agent.dll" ;;
+        *)                   AGENT_NAME="j2c_agent.so" ;;
+    esac
+    HOST_ARCH="$(uname -m)"
+    case "$HOST_ARCH" in
+        x86_64|amd64) : ;;
+        *) warn "native/build.sh targets x86-64 but this host is $HOST_ARCH; the agent may not load. " \
+                "Rebuild for $HOST_ARCH if the dynamic path fails to attach." ;;
+    esac
+    AGENT="$LIBDIR/$AGENT_NAME"
+    # Rebuild when the artifact is missing, empty, or older than any input.
+    needs_build=0
+    if [ ! -s "$AGENT" ]; then
+        needs_build=1
+    else
+        for src in "$ROOT"/native/src/*.cpp "$ROOT"/native/include/* "$ROOT/native/build.sh"; do
+            [ -e "$src" ] || continue
+            if [ "$src" -nt "$AGENT" ]; then needs_build=1; break; fi
+        done
+    fi
+    if [ "$needs_build" -eq 0 ] && [ "$FORCE" -eq 0 ]; then
+        info "Native agent up to date ($AGENT); pass --force to rebuild."
+        NATIVE_READY=1
     elif [ ! -d "$JDK_HOME/include" ]; then
         warn "No JDK headers under '$JDK_HOME/include'; skipping native agent."
         warn "Install a full JDK (not just a JRE), set JAVA_HOME, then re-run."
+        NATIVE_NOTE="native agent skipped (no JDK headers); the dynamic path is unavailable"
     elif ! command -v zig >/dev/null 2>&1 && [ -z "${ZIG:-}" ]; then
         warn "zig not found; skipping native agent (needed only for the dynamic path)."
         warn "Install zig 0.16.x or set ZIG, then re-run. Emulation path needs no native build."
+        NATIVE_NOTE="native agent skipped (zig not found); the dynamic path is unavailable"
     else
         info "Building native JVMTI agent (JDK_HOME=$JDK_HOME)"
         ( cd "$ROOT/native" && JDK_HOME="$JDK_HOME" ZIG="${ZIG:-zig}" bash build.sh ) \
             || die "Native agent build failed. See the output above."
+        NATIVE_READY=1
     fi
 fi
 
-info "Setup finished. Verify with: python -m j2c_dumper_cli doctor"
+if [ "$NATIVE_READY" -eq 1 ]; then
+    info "Setup finished (default dynamic path ready). Verify with: python3 -m j2c_dumper_cli doctor"
+else
+    warn "Setup finished, but $NATIVE_NOTE."
+    warn "Use the emulation fallback, or install the missing piece and re-run."
+    info "Verify with: python3 -m j2c_dumper_cli doctor"
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
doctor / setup / `scripts/j2c`，离线路径 generic 优先、Ghidra 可选。独立复审：**ship-as-draft**（`52ddeb3`）。默认 `recover` 未改。

## (a) 本次改动范围
- doctor、setup、launcher、getting-started / README 离线步骤。

## (b) 是否可直接上线
**可以合入草案。** 不改变产品默认恢复路径。JDK 17。

## (c) 上线前是否需要 review
文档复审已过。

## (d) review 的前置条件
- 已确认离线三步不需要 Ghidra；0x6B8 不再是主说明。

## 验证
- 分支：`cursor/cli-doctor-setup-getting-started-b8b1` @ `52ddeb3`。
- PR：https://github.com/gaoyu06/c2j-native-deobfuscator/pull/6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-459becce-9c8e-4f8a-87ec-4640ea985e25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459becce-9c8e-4f8a-87ec-4640ea985e25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

