### PR TITLE
feat: opt-in JVMTI live attach for an already-running JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ agent the skill and the target, and let it adapt the tools to the binary.
 - **JVMTI agent** (`native/`, C++). Loaded via `-agentpath:` at startup
   (default), or — as an opt-in preview — attached to an already-running,
   same-user JVM via `Agent_OnAttach` (see
-  [`docs/jvm-attach.md`](docs/jvm-attach.md)). Subscribes to
+  [`docs/jvm-attach.md`](docs/jvm-attach.md)). At startup it subscribes to
   `NativeMethodBind`, `MethodEntry`, `MethodExit`, `Exception`,
-  `ExceptionCatch` JVMTI events.
+  `ExceptionCatch`; on a live attach it subscribes only to the events whose
+  capability the JDK still grants (often just `NativeMethodBind` — e.g. on
+  OpenJDK 21).
 - **JNI function table swap**. On `VMInit` and every `ThreadStart`, the
   agent overwrites the `JNIEnv->functions` pointer with a copy whose
   ~80 entries are redirected through logging wrappers. Each wrapper
@@ -301,12 +303,15 @@ python -m j2c_dumper_cli.main attach --pid <pid> --i-own-this-process -o trace.j
 
 This is a **preview** diagnostic path, **not** the default — `recover` still
 uses startup `-agentpath` instrumentation, which observes more. Live attach only
-sees work after attach, and per-JNI-call argument capture is limited to threads
-started after attach (already-running threads still emit method/exception
-events). It requires an explicit `--pid` and the `--i-own-this-process`
-confirmation, and refuses cross-user targets. Full details, supported vs
-unsupported cases, and clean-stop / trace-output notes:
-[`docs/jvm-attach.md`](docs/jvm-attach.md).
+sees work after attach, and coverage depends on which JVMTI capabilities the JDK
+grants *after* attach. On many JDKs (**observed on OpenJDK 21**) only
+native-method-bind is available on a live attach, so the trace holds `bind`
+events and method entry/exit, local-variable, and exception events are **not**
+captured; the agent's `capability` / `gap` records state exactly what was
+obtained. For full method-body recovery use the startup path. Live attach
+requires an explicit `--pid` and the `--i-own-this-process` confirmation, and
+refuses cross-user targets. Full details, supported vs unsupported cases, and
+clean-stop / trace-output notes: [`docs/jvm-attach.md`](docs/jvm-attach.md).
 
 ### Static recovery (when you can't run the jar — needs Ghidra)
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ agent the skill and the target, and let it adapt the tools to the binary.
 
 ### Dynamic path
 
-- **JVMTI agent** (`native/`, C++). Loaded via `-agentpath:`. Subscribes
-  to `NativeMethodBind`, `MethodEntry`, `MethodExit`, `Exception`,
+- **JVMTI agent** (`native/`, C++). Loaded via `-agentpath:` at startup
+  (default), or — as an opt-in preview — attached to an already-running,
+  same-user JVM via `Agent_OnAttach` (see
+  [`docs/jvm-attach.md`](docs/jvm-attach.md)). Subscribes to
+  `NativeMethodBind`, `MethodEntry`, `MethodExit`, `Exception`,
   `ExceptionCatch` JVMTI events.
 - **JNI function table swap**. On `VMInit` and every `ThreadStart`, the
   agent overwrites the `JNIEnv->functions` pointer with a copy whose
@@ -286,6 +289,24 @@ This chains:
 4. `dynamic-trace`     runs the target with the JVMTI agent → `trace.jsonl`
 5. `trace-to-bc`       lifts to `recovered/*.json`
 6. `rebuild`           emits the loader-stripped output jar
+
+### Live process attach (preview — opt-in, same-user)
+
+For a JVM you own that is **already running** and can't be restarted, you can
+attach the same JVMTI agent to the live process instead of using `-agentpath`:
+
+```bash
+python -m j2c_dumper_cli.main attach --pid <pid> --i-own-this-process -o trace.jsonl
+```
+
+This is a **preview** diagnostic path, **not** the default — `recover` still
+uses startup `-agentpath` instrumentation, which observes more. Live attach only
+sees work after attach, and per-JNI-call argument capture is limited to threads
+started after attach (already-running threads still emit method/exception
+events). It requires an explicit `--pid` and the `--i-own-this-process`
+confirmation, and refuses cross-user targets. Full details, supported vs
+unsupported cases, and clean-stop / trace-output notes:
+[`docs/jvm-attach.md`](docs/jvm-attach.md).
 
 ### Static recovery (when you can't run the jar — needs Ghidra)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -245,10 +245,13 @@ python -m j2c_dumper_cli.main attach --pid <pid> --i-own-this-process -o trace.j
 ```
 
 这是**预览**级诊断路径，**不是**默认路径 —— `recover` 仍走启动期 `-agentpath`
-注入（观测更完整）。进程附加只能看到附加之后发生的行为，且逐次 JNI 调用的
-参数捕获只覆盖附加后新建的线程（已在运行的线程仍会产生方法/异常事件）。
-必须显式提供 `--pid` 和 `--i-own-this-process` 确认标志，并且拒绝跨用户目标。
-支持/不支持的情况、干净停止与 trace 输出说明详见
+注入（观测更完整）。进程附加只能看到附加之后发生的行为，且能获得多少覆盖取决于
+JDK 在附加*之后*还允许申请哪些 JVMTI 能力。在不少 JDK 上（**已在 OpenJDK 21
+上实测**），活动附加只能拿到 native-method-bind，因此 trace 只有 `bind` 事件，
+方法进入/退出、局部变量、异常等事件**不会**被捕获；agent 的 `capability` /
+`gap` 记录会如实说明实际获得了什么。要完整恢复方法体请改用启动期路径。
+进程附加必须显式提供 `--pid` 和 `--i-own-this-process` 确认标志，并且拒绝跨用户
+目标。支持/不支持的情况、干净停止与 trace 输出说明详见
 [`docs/jvm-attach.md`](docs/jvm-attach.md)。
 
 ### 静态恢复（目标跑不起来时使用 —— 需要 Ghidra）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,6 +235,22 @@ python -m j2c_dumper_cli.main recover \
 5. `trace-to-bc`       抬升到 `recovered/*.json`
 6. `rebuild`           输出 loader 已剥离的最终 JAR
 
+### 进程附加（预览 —— 可选、仅限同一用户）
+
+如果目标 JVM 是你自己的、且已经在运行、无法重启，可以把同一个 JVMTI agent
+附加到活动进程上，而不必用 `-agentpath`：
+
+```bash
+python -m j2c_dumper_cli.main attach --pid <pid> --i-own-this-process -o trace.jsonl
+```
+
+这是**预览**级诊断路径，**不是**默认路径 —— `recover` 仍走启动期 `-agentpath`
+注入（观测更完整）。进程附加只能看到附加之后发生的行为，且逐次 JNI 调用的
+参数捕获只覆盖附加后新建的线程（已在运行的线程仍会产生方法/异常事件）。
+必须显式提供 `--pid` 和 `--i-own-this-process` 确认标志，并且拒绝跨用户目标。
+支持/不支持的情况、干净停止与 trace 输出说明详见
+[`docs/jvm-attach.md`](docs/jvm-attach.md)。
+
 ### 静态恢复（目标跑不起来时使用 —— 需要 Ghidra）
 
 ```bash

--- a/docs/jvm-attach.md
+++ b/docs/jvm-attach.md
@@ -1,0 +1,191 @@
+# Live JVM process attach (preview)
+
+This document describes the **opt-in** live process-attach path for the JVMTI
+diagnostics agent in [`native/`](../native). It lets you load the agent into a
+JVM that is **already running**, instead of instrumenting it from startup with
+`-agentpath`.
+
+> **Preview, not the default.** The default, highest-fidelity recovery path is
+> still startup instrumentation via `-agentpath` (used by `recover` and
+> `dynamic-trace`). Attaching to a live process observes strictly less: only
+> work that happens *after* the attach, and — for per-JNI-call argument
+> capture — only on threads started after the attach. Use it when you cannot
+> restart the target, or to take a quick diagnostic look at a running JVM.
+
+## Authorized, same-user use only
+
+This path is intended for JVMs **you own or are otherwise authorized to
+inspect**, running as the **same user**. The CLI enforces this with a
+best-effort same-user check and an explicit confirmation flag; it does not, and
+must not, be used to bypass another party's protections. It performs no stealth,
+does not hide the agent, and does not modify the target's behavior beyond
+loading a standard JVMTI agent through the documented attach mechanism.
+
+## How it works
+
+The agent exports `Agent_OnAttach` alongside `Agent_OnLoad`. Both share one
+phase-aware initializer:
+
+- **Startup (`Agent_OnLoad`, `-agentpath`)** — the VM calls `VMInit` and every
+  `ThreadStart`, so the agent installs its logging `JNIEnv` function table on
+  every thread from the beginning.
+- **Live attach (`Agent_OnAttach`)** — the VM is already initialized, so
+  `VMInit` never fires. The agent bootstraps the function-table swap on the
+  attach (listener) thread and picks up every thread started *after* attach via
+  `ThreadStart`. JVMTI event subscriptions (`NativeMethodBind`, `MethodEntry`,
+  `MethodExit`, `Exception`, `ExceptionCatch`) apply process-wide immediately.
+
+Because a JNIEnv function table is per-thread and the agent can only reach the
+attach thread directly, threads that were **already running** at attach time
+keep their original table until they exit. Those threads still produce
+`bind` / `enter` / `exit` / `exception` events (JVMTI, thread-independent) but
+**not** per-JNI-call argument events. The agent records this honestly as a
+capability/coverage gap rather than implying full coverage (see
+[Capability and gap records](#capability-and-gap-records)).
+
+## Usage
+
+### 1. Build the agent
+
+The live-attach path needs the native agent built for the host (dynamic path
+prerequisite). See the README "Quick start":
+
+```bash
+cd native && JDK_HOME="$JAVA_HOME" bash build.sh
+```
+
+`build.sh` uses `zig c++`. If `zig` is not installed the script exits; you can
+build the same three sources with any host C++17 toolchain, e.g.:
+
+```bash
+cd native && mkdir -p build/lib
+g++ -std=c++17 -O2 -shared -fPIC \
+    -I "$JAVA_HOME/include" -I "$JAVA_HOME/include/linux" -I include \
+    -o build/lib/j2c_agent.so \
+    src/agent.cpp src/trace_writer.cpp src/jni_hook.cpp
+```
+
+(or `cmake -S native -B native/build && cmake --build native/build`). The
+result must expose both `Agent_OnLoad` and `Agent_OnAttach`
+(`nm -D build/lib/j2c_agent.so | grep Agent_On`).
+
+### 2. Find the target PID
+
+```bash
+jps -l            # JVM processes for the current user
+# or: pgrep -u "$USER" -f java
+```
+
+### 3. Attach
+
+```bash
+python -m j2c_dumper_cli.main attach \
+    --pid <pid> \
+    --i-own-this-process \
+    -o trace.jsonl
+```
+
+Options:
+
+| Flag | Meaning |
+|---|---|
+| `--pid <pid>` | **Required.** PID of the same-user JVM to attach to. |
+| `--i-own-this-process` | **Required** confirmation of authorized, same-user use. Without it the command refuses before touching the target. |
+| `-o, --output <path>` | Where the agent writes the JSONL trace (default `trace.jsonl`). |
+| `--agent <path>` | Override the agent library (default `native/build/lib/j2c_agent.*`). |
+| `--log-all` | Log JNI calls even outside user native frames. |
+| `--max-frame-events <n>` | Cap JNI events per native frame (`0` = unlimited). |
+| `--mechanism auto\|jcmd\|vm` | Attach mechanism (default `auto`). |
+
+### 4. Exercise the target, then stop cleanly
+
+Drive the target so it executes the obfuscated native methods you care about.
+When done, **stop the target JVM normally** (let it exit, or terminate it the
+way you normally would). `Agent_OnUnload` flushes and closes the trace on VM
+exit. There is no separate detach step; the preview does not support hot
+unloading of the agent.
+
+### 5. Consume the trace
+
+The output is the same `trace.jsonl` schema the startup path produces, so it
+feeds straight into the existing lifter:
+
+```bash
+python -m j2c_dumper_cli.main trace-to-bc trace.jsonl \
+    --manifest manifest.json -o recovered/
+```
+
+(Generate `manifest.json` with `parse-jar` + `inspect-binary` + `merge-manifest`
+as in the README, if you don't already have one.)
+
+## Attach mechanisms
+
+Both mechanisms use the platform's documented JVM attach facility and invoke
+`Agent_OnAttach`:
+
+- **`jcmd`** (default in `auto`): `jcmd <pid> JVMTI.agent_load <lib> "<opts>"`.
+  Ships with the JDK, needs no compilation.
+- **`vm`** (`com.sun.tools.attach`): a tiny helper compiled on demand that calls
+  `VirtualMachine.attach(pid).loadAgentPath(lib, opts)`. Selected with
+  `--mechanism vm`, or used as the `auto` fallback if `jcmd` is unavailable.
+
+## Capability and gap records
+
+On attach the agent writes structured records to the trace before normal events:
+
+- `{"ev":"agent-attached","mode":"live-attach","phase":"live", ...}` — lifecycle
+  marker (the startup path emits `agent-loaded` with `mode":"startup"`).
+- `{"ev":"capability","name":"can_generate_method_entry_events","available":true|false,"phase":"live"}`
+  — one per capability. If a capability is unavailable in the live phase, it is
+  reported `false` (with the JVMTI error code) and the corresponding events are
+  not enabled — coverage is reduced, not faked.
+- `{"ev":"gap","kind":"jni-table-running-threads","tableInstalled":...,"runningThreads":N, ...}`
+  — quantifies the JNI-interception coverage gap for threads already running at
+  attach time.
+- `{"ev":"gap","kind":"no-core-capabilities", ...}` — emitted if neither
+  native-method-bind nor method entry/exit capabilities could be enabled (the
+  trace will be effectively empty).
+
+If the target probes for common inspection flags, the agent continues to use
+only documented JVMTI capabilities and records "capability unavailable" where
+applicable. It does **not** attempt to hide itself or patch the target's checks.
+
+## Supported vs unsupported
+
+**Supported (best-effort):**
+
+- Loading the agent into a live, same-user JVM via `jcmd` or
+  `com.sun.tools.attach`.
+- Full JVMTI event coverage (`bind` / `enter` / `exit` / `exception`) for work
+  that runs after attach, process-wide.
+- Per-JNI-call argument capture on the attach thread and threads started after
+  attach.
+
+**Unsupported / known gaps:**
+
+- **Attach disabled on the target.** If the JVM was started with
+  `-XX:+DisableAttachMechanism` (or `-Djdk.attach.allowAttachSelf=false` for
+  self-attach), the attach handshake fails. There is no workaround from this
+  tool — restart the target and use the startup `-agentpath` path instead.
+- **Dynamic agent loading disabled / warned.** Recent JDKs restrict or warn on
+  dynamically loaded agents (`-XX:-EnableDynamicAgentLoading`, and the
+  "a dynamically loaded agent has been loaded" warning). If dynamic loading is
+  disabled, the attach fails; if it only warns, the attach still succeeds.
+- **Missing `Agent_OnAttach`.** An agent build that does not export
+  `Agent_OnAttach` cannot be attached to a live VM (`AgentInitializationException`
+  / non-zero return). Rebuild the current `native/` sources, which export it.
+- **Permission / same-user errors.** Attaching to another user's process is
+  refused by the JVM attach layer (and pre-refused by this CLI's same-user
+  check). Run as the owning user; do not use elevated privileges to cross users.
+- **Threads already running at attach time** do not get per-JNI-call argument
+  capture (see above) — reported via the `jni-table-running-threads` gap record.
+- **No hot unload.** The preview does not remove the agent from a running VM;
+  stop the target to finish.
+
+## See also
+
+- [README](../README.md) "Quick start" → "Dynamic recovery" for the default
+  startup path.
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) for the agent and pipeline design.
+- [`docs/manual-restoration.md`](manual-restoration.md) for cleaning recovered
+  output by hand.

--- a/docs/jvm-attach.md
+++ b/docs/jvm-attach.md
@@ -162,6 +162,45 @@ the agent failed*. The CLI parses that line and treats any non-zero agent return
 print `attached`. The `vm` helper surfaces the same failure as an
 `AgentInitializationException`, which likewise fails the CLI.
 
+## Common refusals and what this tool does
+
+Live attach can be blocked, or produce only reduced coverage, for several
+routine reasons. The CLI **classifies** each situation into a stable reason code,
+**explains** it, and **recommends** the honest next step — it never bypasses the
+target's flags, hides the agent, patches the target's checks, or reports success
+when the attach did not happen.
+
+Two detection points feed the same small set of reason codes:
+
+- a **pre-attach cmdline scan** of the target's `/proc/<pid>/cmdline` (Linux),
+  so the obvious cases are refused *before* `jcmd`/`VirtualMachine` is invoked;
+- a **post-failure classifier** of the launcher/attach-layer output for cases
+  the argv scan cannot see (e.g. flags set via `JAVA_TOOL_OPTIONS`, or a stale
+  attach socket).
+
+On any refusal the CLI exits non-zero, prints
+`attach failed (reason=<code>): …`, and points to the startup `-agentpath` path.
+It never prints `attached (preview)` in these cases.
+
+| Reason code | Detected when | What the tool does |
+|---|---|---|
+| `attach-disabled` | `-XX:+DisableAttachMechanism` on argv, or the attach handshake is unavailable (`AttachNotSupportedException`, "unable to open socket file", "attach listener", "doesn't respond within …") | Refuse; recommend restarting under startup `-agentpath`. **No bypass** of `DisableAttachMechanism`. |
+| `dynamic-agent-disabled` | `-XX:-EnableDynamicAgentLoading` on argv, or "dynamic agent loading is not enabled" from the attach layer | Refuse; recommend startup `-agentpath`. |
+| `allow-attach-self-disabled` | `-Djdk.attach.allowAttachSelf=false` on argv | Refuse (this only blocks a *self*-attach); attach from a separate process, or use the startup path. |
+| `cross-user` | Same-user check fails pre-attach, or the attach layer refuses on ownership/permission grounds ("operation not permitted", "well-known file is not secure") | Refuse; run as the owning user — **no** privilege escalation to cross users. |
+| `not-a-jvm` | The target does not look like a JVM (pre-attach validation) | Refuse before touching the target. |
+| `agent-onattach-missing` | Attach output shows the agent has no `Agent_OnAttach` export | Refuse; rebuild the current `native/` sources (they export it). |
+| `agent-init-failed` | `Agent_OnAttach` ran but returned non-zero / `AgentInitializationException` | Refuse; check the target JVM's stderr for the agent's own diagnostics. |
+| `jcmd-false-success` | `jcmd` exited 0 but `return code: <N≠0>` | Treat as failure, not success (see "Failure reporting" above). |
+| `unknown` | Attach failed with an unrecognized error | Refuse; include a truncated raw snippet for context. |
+
+**Reduced coverage is not a refusal.** If the attach *succeeds* but the JDK
+grants only bind-only capabilities (the common OpenJDK 21 case), that is honest
+reduced coverage, not a failure: the CLI reports `attached (preview)`, the trace
+carries the `capability` / `gap` records that state exactly what was obtained,
+and the CLI prints a one-line reminder that full method-body recovery needs the
+startup `-agentpath` path. See [Capability and gap records](#capability-and-gap-records).
+
 ## Capability and gap records
 
 On attach the agent writes structured records to the trace before normal events:

--- a/docs/jvm-attach.md
+++ b/docs/jvm-attach.md
@@ -11,6 +11,18 @@ JVM that is **already running**, instead of instrumenting it from startup with
 > work that happens *after* the attach, and — for per-JNI-call argument
 > capture — only on threads started after the attach. Use it when you cannot
 > restart the target, or to take a quick diagnostic look at a running JVM.
+>
+> **Coverage caveat (important).** Several JVMTI capabilities can only be added
+> during the `OnLoad` phase. On many JDKs — **observed on OpenJDK 21** — a live
+> attach can add only `can_generate_native_method_bind_events`; method
+> entry/exit, local-variable access, and exception capabilities return
+> `JVMTI_ERROR_NOT_AVAILABLE` (98). When that happens the live-attach trace
+> contains **only `bind` events** (plus limited `jni-init` records on the attach
+> thread), which is **not** enough for full method-body recovery. The agent
+> records exactly which capabilities it obtained (see
+> [Capability and gap records](#capability-and-gap-records)); do not assume
+> entry/exit/locals/exception coverage unless the matching `capability` record
+> says `available:true`.
 
 ## Authorized, same-user use only
 
@@ -32,15 +44,21 @@ phase-aware initializer:
 - **Live attach (`Agent_OnAttach`)** — the VM is already initialized, so
   `VMInit` never fires. The agent bootstraps the function-table swap on the
   attach (listener) thread and picks up every thread started *after* attach via
-  `ThreadStart`. JVMTI event subscriptions (`NativeMethodBind`, `MethodEntry`,
-  `MethodExit`, `Exception`, `ExceptionCatch`) apply process-wide immediately.
+  `ThreadStart`. It then *attempts* to add each JVMTI capability
+  (`can_generate_native_method_bind_events`, `..._method_entry_events`,
+  `..._method_exit_events`, `can_access_local_variables`,
+  `..._exception_events`) and subscribes only to the events whose capability was
+  actually granted in the live phase. On JDKs where the entry/exit/locals/
+  exception capabilities are `OnLoad`-only (e.g. OpenJDK 21), only
+  `NativeMethodBind` is subscribed.
 
 Because a JNIEnv function table is per-thread and the agent can only reach the
 attach thread directly, threads that were **already running** at attach time
-keep their original table until they exit. Those threads still produce
-`bind` / `enter` / `exit` / `exception` events (JVMTI, thread-independent) but
-**not** per-JNI-call argument events. The agent records this honestly as a
-capability/coverage gap rather than implying full coverage (see
+keep their original table until they exit. Those threads still produce whichever
+of the `bind` / `enter` / `exit` / `exception` events the agent could enable
+(thread-independent JVMTI events) — **typically only `bind` on a live attach** —
+but **not** per-JNI-call argument events. The agent records this honestly as
+`capability` and `gap` records rather than implying full coverage (see
 [Capability and gap records](#capability-and-gap-records)).
 
 ## Usage
@@ -123,28 +141,58 @@ as in the README, if you don't already have one.)
 Both mechanisms use the platform's documented JVM attach facility and invoke
 `Agent_OnAttach`:
 
-- **`jcmd`** (default in `auto`): `jcmd <pid> JVMTI.agent_load <lib> "<opts>"`.
-  Ships with the JDK, needs no compilation.
+- **`jcmd`** (default in `auto`): `jcmd <pid> JVMTI.agent_load <lib> '<opts>'`.
+  Ships with the JDK, needs no compilation. **The option string must be
+  single-quoted.** `jcmd JVMTI.agent_load` routes the option string through the
+  diagnostic-command argument parser, which treats a `key=value` token as one of
+  its *own* named arguments and, for a positional argument, keeps only the part
+  before `=`. A bare `trace=out.jsonl` therefore reaches the agent as an empty
+  trace path; single-quoting makes the parser take the whole string as one
+  literal positional value so the agent receives it intact. The CLI does this
+  for you.
 - **`vm`** (`com.sun.tools.attach`): a tiny helper compiled on demand that calls
   `VirtualMachine.attach(pid).loadAgentPath(lib, opts)`. Selected with
   `--mechanism vm`, or used as the `auto` fallback if `jcmd` is unavailable.
+  `loadAgentPath` passes the option string verbatim (no quoting needed).
+
+**Failure reporting.** `jcmd JVMTI.agent_load` prints `return code: <N>` (the
+value `Agent_OnAttach` returned) but the `jcmd` process itself exits 0 *even when
+the agent failed*. The CLI parses that line and treats any non-zero agent return
+(or a non-zero `jcmd` exit) as a hard failure: it exits non-zero and does **not**
+print `attached`. The `vm` helper surfaces the same failure as an
+`AgentInitializationException`, which likewise fails the CLI.
 
 ## Capability and gap records
 
 On attach the agent writes structured records to the trace before normal events:
 
-- `{"ev":"agent-attached","mode":"live-attach","phase":"live", ...}` — lifecycle
-  marker (the startup path emits `agent-loaded` with `mode":"startup"`).
+- `{"ev":"agent-attached","mode":"live-attach","phase":"live","logAll":true|false,"trace":"..."}`
+  — lifecycle marker (the startup path emits `agent-loaded` with
+  `"mode":"startup"`). `logAll` reflects the `--log-all` / `log-all=true` option.
 - `{"ev":"capability","name":"can_generate_method_entry_events","available":true|false,"phase":"live"}`
   — one per capability. If a capability is unavailable in the live phase, it is
-  reported `false` (with the JVMTI error code) and the corresponding events are
-  not enabled — coverage is reduced, not faked.
-- `{"ev":"gap","kind":"jni-table-running-threads","tableInstalled":...,"runningThreads":N, ...}`
+  reported `false` with the JVMTI error code (`98` =
+  `JVMTI_ERROR_NOT_AVAILABLE`) and the corresponding events are not enabled —
+  coverage is reduced, not faked.
+- `{"ev":"gap","kind":"reduced-live-capabilities","nativeMethodBind":true,"methodEntry":false,"methodExit":false,"localVariables":false,"exceptions":false,"enabledEvents":"native-method-bind", ...}`
+  — emitted on a live attach whenever entry/exit, local-variable, or exception
+  capabilities could **not** be added. It states precisely which events are
+  active; the missing ones will never appear in the trace. This is the common
+  case on OpenJDK 21.
+- `{"ev":"gap","kind":"jni-table-running-threads","tableInstalled":...,"runningThreads":N,"enabledEvents":"...", ...}`
   — quantifies the JNI-interception coverage gap for threads already running at
-  attach time.
+  attach time. `enabledEvents` names only the process-wide events actually
+  enabled for the phase (so it does not imply enter/exit/exception when those
+  capabilities were denied).
 - `{"ev":"gap","kind":"no-core-capabilities", ...}` — emitted if neither
   native-method-bind nor method entry/exit capabilities could be enabled (the
   trace will be effectively empty).
+
+Together these records let a reader reconstruct exactly what the attach obtained.
+For example, a typical OpenJDK 21 live attach yields `native-method-bind`
+`available:true` and `method-entry` / `method-exit` / `can_access_local_variables`
+/ `exception` all `available:false` with `jvmtiError:98`, plus a
+`reduced-live-capabilities` gap — i.e. `bind` events only.
 
 If the target probes for common inspection flags, the agent continues to use
 only documented JVMTI capabilities and records "capability unavailable" where
@@ -156,10 +204,16 @@ applicable. It does **not** attempt to hide itself or patch the target's checks.
 
 - Loading the agent into a live, same-user JVM via `jcmd` or
   `com.sun.tools.attach`.
-- Full JVMTI event coverage (`bind` / `enter` / `exit` / `exception`) for work
-  that runs after attach, process-wide.
-- Per-JNI-call argument capture on the attach thread and threads started after
-  attach.
+- `NativeMethodBind` events (the `[native fn pointer -> Java method]` table) for
+  work that runs after attach, process-wide — this capability is the one that
+  reliably survives a live attach.
+- Method `enter` / `exit` / `exception` events **and** per-JNI-call argument
+  capture (on the attach thread and threads started after attach) **only when
+  the JDK grants those capabilities after attach.** On JDKs where they are
+  `OnLoad`-only (e.g. OpenJDK 21) these are **not** available on a live attach —
+  the `capability` / `reduced-live-capabilities` records will say so, and the
+  trace will hold `bind` events only. For full method-body recovery, use the
+  startup `-agentpath` path.
 
 **Unsupported / known gaps:**
 

--- a/docs/jvm-attach.md
+++ b/docs/jvm-attach.md
@@ -186,13 +186,25 @@ It never prints `attached (preview)` in these cases.
 |---|---|---|
 | `attach-disabled` | `-XX:+DisableAttachMechanism` on argv, or the attach handshake is unavailable (`AttachNotSupportedException`, "unable to open socket file", "attach listener", "doesn't respond within …") | Refuse; recommend restarting under startup `-agentpath`. **No bypass** of `DisableAttachMechanism`. |
 | `dynamic-agent-disabled` | `-XX:-EnableDynamicAgentLoading` on argv, or "dynamic agent loading is not enabled" from the attach layer | Refuse; recommend startup `-agentpath`. |
-| `allow-attach-self-disabled` | `-Djdk.attach.allowAttachSelf=false` on argv | Refuse (this only blocks a *self*-attach); attach from a separate process, or use the startup path. |
 | `cross-user` | Same-user check fails pre-attach, or the attach layer refuses on ownership/permission grounds ("operation not permitted", "well-known file is not secure") | Refuse; run as the owning user — **no** privilege escalation to cross users. |
 | `not-a-jvm` | The target does not look like a JVM (pre-attach validation) | Refuse before touching the target. |
 | `agent-onattach-missing` | Attach output shows the agent has no `Agent_OnAttach` export | Refuse; rebuild the current `native/` sources (they export it). |
 | `agent-init-failed` | `Agent_OnAttach` ran but returned non-zero / `AgentInitializationException` | Refuse; check the target JVM's stderr for the agent's own diagnostics. |
 | `jcmd-false-success` | `jcmd` exited 0 but `return code: <N≠0>` | Treat as failure, not success (see "Failure reporting" above). |
 | `unknown` | Attach failed with an unrecognized error | Refuse; include a truncated raw snippet for context. |
+
+Both pre-validation refusals — `cross-user` (owner uid ≠ current uid) and
+`not-a-jvm` (the target does not look like a JVM) — print the same
+`attach failed (reason=<code>): …` line as the rows above, exit non-zero, and
+never print `attached (preview)`.
+
+**`jdk.attach.allowAttachSelf=false` is not a refusal.** This property disables
+a JVM attaching to *its own* process (self-attach). It does **not** block an
+external, same-user attach from this CLI, so the pre-attach scan only **warns**
+(`target sets jdk.attach.allowAttachSelf=false … proceeding.`) and continues —
+it does not refuse a valid same-user target on the strength of a flag that does
+not apply to us. The hard pre-scan refusals remain `-XX:+DisableAttachMechanism`
+and `-XX:-EnableDynamicAgentLoading`.
 
 **Reduced coverage is not a refusal.** If the attach *succeeds* but the JDK
 grants only bind-only capabilities (the common OpenJDK 21 case), that is honest
@@ -257,9 +269,11 @@ applicable. It does **not** attempt to hide itself or patch the target's checks.
 **Unsupported / known gaps:**
 
 - **Attach disabled on the target.** If the JVM was started with
-  `-XX:+DisableAttachMechanism` (or `-Djdk.attach.allowAttachSelf=false` for
-  self-attach), the attach handshake fails. There is no workaround from this
-  tool — restart the target and use the startup `-agentpath` path instead.
+  `-XX:+DisableAttachMechanism`, the attach handshake fails. There is no
+  workaround from this tool — restart the target and use the startup
+  `-agentpath` path instead. (Note `-Djdk.attach.allowAttachSelf=false` is
+  *not* in this category: it only disables a JVM attaching to itself and does
+  not block this external, same-user attach — the CLI warns and proceeds.)
 - **Dynamic agent loading disabled / warned.** Recent JDKs restrict or warn on
   dynamically loaded agents (`-XX:-EnableDynamicAgentLoading`, and the
   "a dynamically loaded agent has been loaded" warning). If dynamic loading is

--- a/docs/reviews/jvm-attach.md
+++ b/docs/reviews/jvm-attach.md
@@ -1,0 +1,151 @@
+# Review: opt-in live JVM process-attach preview
+
+Scope of this review: the opt-in live process-attach path added for the JVMTI
+diagnostics agent — the `attach` CLI command, its `attach_support` helpers, the
+`Agent_OnAttach` entry point, and the accompanying docs. This is a **preview**
+diagnostic path; the default `recover` flow still uses startup `-agentpath`
+instrumentation and was left unchanged except where noted below.
+
+All findings were reproduced empirically on **OpenJDK 21** (Linux, x86-64) with
+the agent compiled from `native/`.
+
+## Must-fix findings and resolutions
+
+### 1. `jcmd` reported false success on agent-load failure
+
+**Finding.** The CLI built a bare, comma-separated agent option string
+(`trace=out.jsonl,log-all=true,...`) and passed it to
+`jcmd <pid> JVMTI.agent_load <lib> <opts>`. Two problems compounded:
+
+- **Option string was silently corrupted.** `jcmd JVMTI.agent_load` routes the
+  option through the diagnostic-command argument parser. That parser treats a
+  `key=value` token as one of its own named arguments and, for a positional
+  argument, keeps only the part *before* `=`. So `trace=/path` reached the agent
+  as an empty trace path. `Agent_OnAttach` then failed to open the trace file
+  and returned `JNI_ERR` (`-1`).
+  - Reproduction: `jcmd <pid> JVMTI.agent_load <lib> trace=/tmp/t.jsonl` →
+    agent stderr `j2c-agent: failed to open trace file: ` (empty path).
+- **`jcmd` masked the failure.** `jcmd JVMTI.agent_load` prints
+  `return code: -1` on stdout but the `jcmd` process still exits `0`. The CLI
+  keyed off the process exit code, so it printed `attached (preview).` for a
+  load that had actually failed.
+
+**Resolution.**
+
+- The agent option string is now **single-quoted** when passed to `jcmd`
+  (`build_jcmd_agent_load_argv` / `jcmd_agent_option_arg`). The diagnostic-command
+  parser then takes the whole string as one literal positional value, so the
+  agent receives `trace=…,log-all=…,…` intact. Verified: the trace file is
+  created at the requested path and `return code: 0`.
+- The CLI now captures `jcmd` stdout/stderr and parses the `return code:` line
+  (`parse_jcmd_return_code` / `jcmd_load_error`). A non-zero agent return **or** a
+  non-zero `jcmd` process exit is treated as a hard failure: the CLI exits
+  non-zero and does **not** print `attached`. Verified end-to-end (agent forced
+  to fail → CLI exit 1, no `attached`).
+- The `com.sun.tools.attach` (`vm`) mechanism already passes the option string
+  verbatim and surfaces failure as `AgentInitializationException`; that path was
+  confirmed to fail the CLI too. The `auto` mechanism now falls back from `jcmd`
+  to `vm` **only** when `jcmd` is unavailable, so a genuine load failure is no
+  longer retried (which would have reloaded the agent).
+
+**Tests added** (`tests/test_attach.py`, no JVM required):
+
+- Option form: `jcmd_agent_option_arg` / `build_jcmd_agent_load_argv` produce a
+  single-quoted option argument (would have failed against the old bare form).
+- Return-code parsing: `return code: -1` → `-1`, `return code: 0` → `0`, absent
+  → `None`; `jcmd_load_error` flags a `-1` agent return *despite* process exit 0.
+- CLI level (mocked `subprocess.run`): a simulated `jcmd` exit-0 + `return code:
+  -1` makes `attach` exit non-zero and never print `attached`; the mirrored
+  success case does print it.
+
+### 2. Coverage claims did not match what a live attach actually obtains
+
+**Finding.** Several JVMTI capabilities are `OnLoad`-only. On OpenJDK 21 a live
+attach could add **only** `can_generate_native_method_bind_events`; method
+entry, method exit, local-variable access, and exception capabilities all
+returned `JVMTI_ERROR_NOT_AVAILABLE` (98). The docs and README pointers,
+however, promised "full JVMTI event coverage (`bind`/`enter`/`exit`/`exception`)"
+and stated that already-running threads "still emit bind/enter/exit/exception
+events" — neither is true when those capabilities are denied.
+
+Reproduced capability records from a live attach on OpenJDK 21:
+
+```
+capability can_generate_native_method_bind_events available:true
+capability can_generate_method_entry_events        available:false jvmtiError:98
+capability can_generate_method_exit_events         available:false jvmtiError:98
+capability can_access_local_variables              available:false jvmtiError:98
+capability can_generate_exception_events           available:false jvmtiError:98
+```
+
+**Resolution.**
+
+- **Emitted records now describe what was actually obtained.**
+  - New `gap` record `reduced-live-capabilities` fires on a live attach whenever
+    entry/exit, local-variable, or exception capabilities could not be added. It
+    reports the exact per-capability booleans and the list of `enabledEvents`.
+  - The `jni-table-running-threads` gap now lists only the events actually
+    enabled for the phase (`enabledEvents`) instead of unconditionally claiming
+    `bind/enter/exit/exception`.
+  - The `agent-attached` / `agent-loaded` lifecycle record now includes
+    `logAll`.
+  - The per-capability `capability` records (already honest, `available:true|
+    false` with the JVMTI error code) are unchanged.
+- **Docs corrected** (`docs/jvm-attach.md`, `README.md`, `README.zh-CN.md`, and
+  the `attach --help` text): they now state that a live attach may obtain only
+  native-method-bind (observed on OpenJDK 21), that entry/exit/locals/exception
+  are not promised unless the matching `capability` record says `available:true`,
+  and that full method-body recovery needs the startup `-agentpath` path.
+
+No new capabilities were added, so no coverage is now promised that the agent
+does not obtain.
+
+### 3. `--log-all` was a dead switch
+
+**Finding.** `--log-all` flowed into the `log-all=true` agent option and set a
+module-level `g_log_all` in `agent.cpp`, but nothing ever read it. The JNI-call
+logging gate (`emit`) only checked `in_native_frame()`, so the flag changed
+nothing.
+
+**Resolution.** Wired the flag into the logging path:
+
+- Added `set_log_all()` / `log_all()` to `jni_hook` and a `log-all=true` handler
+  in `parse_options`.
+- `emit` (and `emit_propagate`) now log calls made *outside* a user native frame
+  when `log-all` is enabled, while the default behavior is unchanged (outside-
+  frame calls stay suppressed). The per-frame event budget still applies only
+  inside a frame.
+- The redundant `agent.cpp` global was removed; the `log-all` state is surfaced
+  in the `agent-attached` / `agent-loaded` record (`logAll`).
+
+Verified on the startup path: with `-agentpath:…=…,log-all=true` the trace gained
+480 outside-frame `jni` records for a short run that produced **0** without the
+flag.
+
+## What was intentionally left unchanged
+
+- **Default `recover` path.** Startup `-agentpath` instrumentation is untouched;
+  it still obtains the full capability set (all five capabilities `available:true`
+  in the startup phase, verified).
+- **No stealth / evasion / kernel / TLS hooks.** The agent uses only documented
+  JVMTI capabilities and the documented attach mechanisms; it does not hide
+  itself or alter target behavior beyond loading a standard JVMTI agent.
+- **Same-user / ownership guardrails.** `--i-own-this-process`, the required
+  explicit `--pid`, and the same-user / looks-like-Java validation are retained.
+
+## Known limitations / leftovers
+
+- On JDKs where entry/exit/locals/exception capabilities are `OnLoad`-only (e.g.
+  OpenJDK 21), a live attach yields only `bind` coverage. This is a JVM
+  limitation, not something this tool can work around; the startup path remains
+  the way to get full coverage.
+- The trace writer flushes on `Agent_OnUnload` (clean VM stop). A hard kill
+  (`SIGKILL`) of the target can lose buffered records. Stopping the target
+  normally is required, as the docs state.
+- `jcmd` cannot carry an agent option string that itself contains a single
+  quote; `jcmd_agent_option_arg` refuses such input and points the user to
+  `--mechanism vm`. Trace paths with an apostrophe are out of scope for the
+  preview.
+- Threads already running at attach time never receive per-JNI-call argument
+  capture (their JNIEnv table is not swapped); this is reported via the
+  `jni-table-running-threads` gap record.

--- a/native/include/jni_hook.hpp
+++ b/native/include/jni_hook.hpp
@@ -28,6 +28,12 @@ void exit_suppress_frame();
 // Configure the max events per outermost-native-frame budget. <=0 disables.
 void set_max_frame_events(int n);
 
+// When enabled, JNI-call wrappers also log calls made *outside* a user native
+// frame (normally suppressed as noise). Wired to the `log-all=true` agent
+// option. Off by default.
+void set_log_all(bool on);
+bool log_all();
+
 // Current method being entered (for "fn" field of enter/exit events).
 void set_current_native_method(const char* sig);
 const char* current_native_method();

--- a/native/src/agent.cpp
+++ b/native/src/agent.cpp
@@ -246,10 +246,89 @@ void JNICALL on_method_exit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread,
     hook::exit_native_frame();
 }
 
-} // namespace
+const char* phase_name(jvmtiPhase p) {
+    switch (p) {
+        case JVMTI_PHASE_ONLOAD:     return "onload";
+        case JVMTI_PHASE_PRIMORDIAL: return "primordial";
+        case JVMTI_PHASE_START:      return "start";
+        case JVMTI_PHASE_LIVE:       return "live";
+        case JVMTI_PHASE_DEAD:       return "dead";
+        default:                     return "unknown";
+    }
+}
 
-extern "C" JNIEXPORT jint JNICALL
-Agent_OnLoad(JavaVM* vm, char* options, void* /*reserved*/) {
+// Try to add a single JVMTI capability and emit a "capability" record noting
+// whether it is available in the current phase. On a live (process attach)
+// start, some capabilities the startup path takes for granted may be
+// OnLoad-only or otherwise unavailable; we record that honestly instead of
+// silently dropping coverage. Returns true iff the capability is now enabled.
+bool add_capability(jvmtiEnv* jvmti, const jvmtiCapabilities& cap,
+                    const char* name, const char* phase) {
+    jvmtiError e = jvmti->AddCapabilities(&cap);
+    bool ok = (e == JVMTI_ERROR_NONE);
+    std::ostringstream os;
+    os << "{\"ev\":\"capability\",\"ts\":" << TraceWriter::ts_now()
+       << ",\"thr\":" << TraceWriter::tid()
+       << ",\"name\":" << esc(name)
+       << ",\"available\":" << (ok ? "true" : "false")
+       << ",\"phase\":" << esc(phase);
+    if (!ok) os << ",\"jvmtiError\":" << static_cast<int>(e);
+    os << "}";
+    TraceWriter::instance().write_line(os.str());
+    return ok;
+}
+
+void emit_gap(const char* kind, const char* phase, const std::string& detail,
+              const std::string& extra = std::string()) {
+    std::ostringstream os;
+    os << "{\"ev\":\"gap\",\"ts\":" << TraceWriter::ts_now()
+       << ",\"thr\":" << TraceWriter::tid()
+       << ",\"kind\":" << esc(kind)
+       << ",\"phase\":" << esc(phase);
+    if (!extra.empty()) os << "," << extra;
+    os << ",\"detail\":" << esc(detail.c_str()) << "}";
+    TraceWriter::instance().write_line(os.str());
+}
+
+// On a live attach the VM is already running, so VMInit will never fire and
+// the JNIEnv function table swap that VMInit/ThreadStart normally performs must
+// be bootstrapped here. We can only reach the *current* (attach-listener)
+// thread's JNIEnv; already-running application threads keep their original
+// table until they exit. We install on the current thread (so the hooked table
+// is built and picked up by every future ThreadStart) and record the coverage
+// gap for the threads we cannot reach.
+void install_on_live_threads(JavaVM* vm, jvmtiEnv* jvmti, const char* phase) {
+    JNIEnv* jni = nullptr;
+    jint gr = vm->GetEnv(reinterpret_cast<void**>(&jni), JNI_VERSION_1_6);
+    bool table_installed = false;
+    if (gr == JNI_OK && jni != nullptr) {
+        hook::capture_original(jni);
+        hook::install(jni);
+        table_installed = true;
+    }
+
+    jint count = -1;
+    jthread* threads = nullptr;
+    if (jvmti->GetAllThreads(&count, &threads) != JVMTI_ERROR_NONE) {
+        count = -1;
+    } else if (threads) {
+        jvmti->Deallocate(reinterpret_cast<unsigned char*>(threads));
+    }
+
+    std::ostringstream extra;
+    extra << "\"tableInstalled\":" << (table_installed ? "true" : "false")
+          << ",\"runningThreads\":" << count;
+    emit_gap("jni-table-running-threads", phase,
+             "live attach installs JNI wrappers on the attach thread and every "
+             "thread started afterwards; native methods on already-running "
+             "threads still emit bind/enter/exit/exception (JVMTI) events but "
+             "not per-JNI-call argument events",
+             extra.str());
+}
+
+// Shared initialization for both startup (-agentpath, Agent_OnLoad) and live
+// process attach (Agent_OnAttach). `live_attach` selects phase-aware behavior.
+jint init_agent(JavaVM* vm, char* options, bool live_attach) {
     parse_options(options);
     TraceWriter::instance().open(g_trace_path);
     if (!TraceWriter::instance().is_open()) {
@@ -263,47 +342,98 @@ Agent_OnLoad(JavaVM* vm, char* options, void* /*reserved*/) {
         return JNI_ERR;
     }
 
-    jvmtiCapabilities caps{};
-    caps.can_generate_method_entry_events = 1;
-    caps.can_generate_method_exit_events = 1;
-    caps.can_generate_native_method_bind_events = 1;
-    // Needed to read parameter values of a native method at MethodEntry —
-    // see read_method_params() and `params` field on enter events.
-    caps.can_access_local_variables = 1;
-    // Exception events drive recovery of try/catch tables — see #4.
-    caps.can_generate_exception_events = 1;
-    if (jvmti->AddCapabilities(&caps) != JVMTI_ERROR_NONE) {
-        std::fprintf(stderr, "j2c-agent: AddCapabilities failed\n");
-        return JNI_ERR;
+    jvmtiPhase phase = JVMTI_PHASE_ONLOAD;
+    jvmti->GetPhase(&phase);
+    const char* pname = phase_name(phase);
+
+    std::ostringstream lc;
+    lc << "{\"ev\":" << (live_attach ? "\"agent-attached\"" : "\"agent-loaded\"")
+       << ",\"ts\":" << TraceWriter::ts_now()
+       << ",\"thr\":" << TraceWriter::tid()
+       << ",\"mode\":" << esc(live_attach ? "live-attach" : "startup")
+       << ",\"phase\":" << esc(pname)
+       << ",\"trace\":" << esc(g_trace_path.c_str()) << "}";
+    TraceWriter::instance().write_line(lc.str());
+
+    // Add capabilities one at a time (AddCapabilities is additive) so that a
+    // single unavailable capability on live attach does not sink the rest.
+    auto cap_bit = [](void (*set)(jvmtiCapabilities&)) {
+        jvmtiCapabilities c{};
+        set(c);
+        return c;
+    };
+    bool cap_bind = add_capability(jvmti,
+        cap_bit([](jvmtiCapabilities& c) { c.can_generate_native_method_bind_events = 1; }),
+        "can_generate_native_method_bind_events", pname);
+    bool cap_entry = add_capability(jvmti,
+        cap_bit([](jvmtiCapabilities& c) { c.can_generate_method_entry_events = 1; }),
+        "can_generate_method_entry_events", pname);
+    bool cap_exit = add_capability(jvmti,
+        cap_bit([](jvmtiCapabilities& c) { c.can_generate_method_exit_events = 1; }),
+        "can_generate_method_exit_events", pname);
+    // Needed to read parameter values of a native method at MethodEntry.
+    add_capability(jvmti,
+        cap_bit([](jvmtiCapabilities& c) { c.can_access_local_variables = 1; }),
+        "can_access_local_variables", pname);
+    // Exception events drive recovery of try/catch tables.
+    bool cap_exc = add_capability(jvmti,
+        cap_bit([](jvmtiCapabilities& c) { c.can_generate_exception_events = 1; }),
+        "can_generate_exception_events", pname);
+
+    if (!cap_bind && !cap_entry && !cap_exit) {
+        emit_gap("no-core-capabilities", pname,
+                 "neither native-method-bind nor method entry/exit capabilities "
+                 "are available in this phase; the recovery trace will be empty");
     }
 
     jvmtiEventCallbacks cbs{};
     cbs.VMInit = on_vm_init;
     cbs.ThreadStart = on_thread_start;
-    cbs.NativeMethodBind = on_native_method_bind;
-    cbs.MethodEntry = on_method_entry;
-    cbs.MethodExit = on_method_exit;
-    cbs.Exception = on_exception;
-    cbs.ExceptionCatch = on_exception_catch;
+    if (cap_bind)  cbs.NativeMethodBind = on_native_method_bind;
+    if (cap_entry) cbs.MethodEntry = on_method_entry;
+    if (cap_exit)  cbs.MethodExit = on_method_exit;
+    if (cap_exc) {
+        cbs.Exception = on_exception;
+        cbs.ExceptionCatch = on_exception_catch;
+    }
     if (jvmti->SetEventCallbacks(&cbs, sizeof(cbs)) != JVMTI_ERROR_NONE) {
         std::fprintf(stderr, "j2c-agent: SetEventCallbacks failed\n");
         return JNI_ERR;
     }
 
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, nullptr);
+    // On startup VMInit installs the JNI table; on live attach it never fires.
+    if (!live_attach) {
+        jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, nullptr);
+    }
     jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, nullptr);
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, nullptr);
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, nullptr);
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, nullptr);
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, nullptr);
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, nullptr);
+    if (cap_bind)  jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, nullptr);
+    if (cap_entry) jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, nullptr);
+    if (cap_exit)  jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, nullptr);
+    if (cap_exc) {
+        jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, nullptr);
+        jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, nullptr);
+    }
 
-    std::ostringstream os;
-    os << "{\"ev\":\"agent-loaded\",\"ts\":" << TraceWriter::ts_now()
-       << ",\"thr\":" << TraceWriter::tid()
-       << ",\"trace\":" << esc(g_trace_path.c_str()) << "}";
-    TraceWriter::instance().write_line(os.str());
+    if (live_attach) {
+        install_on_live_threads(vm, jvmti, pname);
+    }
+
     return JNI_OK;
+}
+
+} // namespace
+
+extern "C" JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM* vm, char* options, void* /*reserved*/) {
+    return init_agent(vm, options, /*live_attach=*/false);
+}
+
+// Entry point for live process attach (JDK attach API / com.sun.tools.attach
+// loadAgentPath, or `jcmd <pid> JVMTI.agent_load`). Shares initialization with
+// Agent_OnLoad but is phase-aware: the VM is already running.
+extern "C" JNIEXPORT jint JNICALL
+Agent_OnAttach(JavaVM* vm, char* options, void* /*reserved*/) {
+    return init_agent(vm, options, /*live_attach=*/true);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/native/src/agent.cpp
+++ b/native/src/agent.cpp
@@ -28,7 +28,6 @@ namespace hook = j2c::jni_hook;
 namespace {
 
 std::string g_trace_path = "trace.jsonl";
-bool g_log_all = false; // log even outside __ngen native frames
 
 std::string esc(const char* s) {
     if (!s) return "null";
@@ -68,7 +67,7 @@ void parse_options(const char* options) {
         std::string k = pair.substr(0, eq);
         std::string v = eq == std::string::npos ? "" : pair.substr(eq + 1);
         if (k == "trace") g_trace_path = v;
-        else if (k == "log-all" && (v == "1" || v == "true")) g_log_all = true;
+        else if (k == "log-all" && (v == "1" || v == "true")) hook::set_log_all(true);
         else if (k == "max-frame-events") {
             try { hook::set_max_frame_events(std::stoi(v)); } catch (...) {}
         }
@@ -297,7 +296,8 @@ void emit_gap(const char* kind, const char* phase, const std::string& detail,
 // table until they exit. We install on the current thread (so the hooked table
 // is built and picked up by every future ThreadStart) and record the coverage
 // gap for the threads we cannot reach.
-void install_on_live_threads(JavaVM* vm, jvmtiEnv* jvmti, const char* phase) {
+void install_on_live_threads(JavaVM* vm, jvmtiEnv* jvmti, const char* phase,
+                             const std::string& enabled_events) {
     JNIEnv* jni = nullptr;
     jint gr = vm->GetEnv(reinterpret_cast<void**>(&jni), JNI_VERSION_1_6);
     bool table_installed = false;
@@ -317,13 +317,17 @@ void install_on_live_threads(JavaVM* vm, jvmtiEnv* jvmti, const char* phase) {
 
     std::ostringstream extra;
     extra << "\"tableInstalled\":" << (table_installed ? "true" : "false")
-          << ",\"runningThreads\":" << count;
-    emit_gap("jni-table-running-threads", phase,
-             "live attach installs JNI wrappers on the attach thread and every "
-             "thread started afterwards; native methods on already-running "
-             "threads still emit bind/enter/exit/exception (JVMTI) events but "
-             "not per-JNI-call argument events",
-             extra.str());
+          << ",\"runningThreads\":" << count
+          << ",\"enabledEvents\":" << esc(enabled_events.c_str());
+    // Only claim the events we actually enabled for this phase. Threads already
+    // running at attach time still receive those process-wide JVMTI events, but
+    // never per-JNI-call argument events (their JNIEnv table is unchanged).
+    std::string detail =
+        "live attach installs JNI wrappers on the attach thread and every thread "
+        "started afterwards; threads already running at attach time still emit "
+        "the process-wide JVMTI events enabled in this phase (" + enabled_events +
+        ") but not per-JNI-call argument events";
+    emit_gap("jni-table-running-threads", phase, detail, extra.str());
 }
 
 // Shared initialization for both startup (-agentpath, Agent_OnLoad) and live
@@ -352,6 +356,7 @@ jint init_agent(JavaVM* vm, char* options, bool live_attach) {
        << ",\"thr\":" << TraceWriter::tid()
        << ",\"mode\":" << esc(live_attach ? "live-attach" : "startup")
        << ",\"phase\":" << esc(pname)
+       << ",\"logAll\":" << (hook::log_all() ? "true" : "false")
        << ",\"trace\":" << esc(g_trace_path.c_str()) << "}";
     TraceWriter::instance().write_line(lc.str());
 
@@ -372,7 +377,7 @@ jint init_agent(JavaVM* vm, char* options, bool live_attach) {
         cap_bit([](jvmtiCapabilities& c) { c.can_generate_method_exit_events = 1; }),
         "can_generate_method_exit_events", pname);
     // Needed to read parameter values of a native method at MethodEntry.
-    add_capability(jvmti,
+    bool cap_locals = add_capability(jvmti,
         cap_bit([](jvmtiCapabilities& c) { c.can_access_local_variables = 1; }),
         "can_access_local_variables", pname);
     // Exception events drive recovery of try/catch tables.
@@ -380,10 +385,43 @@ jint init_agent(JavaVM* vm, char* options, bool live_attach) {
         cap_bit([](jvmtiCapabilities& c) { c.can_generate_exception_events = 1; }),
         "can_generate_exception_events", pname);
 
+    // Describe exactly which thread-independent JVMTI events we could enable, so
+    // downstream records never imply coverage we do not actually have.
+    std::string enabled_events;
+    auto add_ev = [&](bool on, const char* n) {
+        if (on) { if (!enabled_events.empty()) enabled_events += ", "; enabled_events += n; }
+    };
+    add_ev(cap_bind,  "native-method-bind");
+    add_ev(cap_entry, "method-entry");
+    add_ev(cap_exit,  "method-exit");
+    add_ev(cap_exc,   "exception/exception-catch");
+    if (enabled_events.empty()) enabled_events = "none";
+
     if (!cap_bind && !cap_entry && !cap_exit) {
         emit_gap("no-core-capabilities", pname,
                  "neither native-method-bind nor method entry/exit capabilities "
                  "are available in this phase; the recovery trace will be empty");
+    } else if (live_attach && (!cap_entry || !cap_exit || !cap_exc || !cap_locals)) {
+        // On many JDKs (observed on OpenJDK 21) a live attach can only add
+        // native-method-bind; method entry/exit, local-variable access, and
+        // exception capabilities return JVMTI_ERROR_NOT_AVAILABLE in the live
+        // phase. Record precisely what was obtained rather than implying full
+        // coverage. Without method entry/exit there is no user-native-frame
+        // detection, so per-JNI-call argument events (which gate on being inside
+        // such a frame) will not be produced either.
+        std::ostringstream extra;
+        extra << "\"nativeMethodBind\":" << (cap_bind ? "true" : "false")
+              << ",\"methodEntry\":" << (cap_entry ? "true" : "false")
+              << ",\"methodExit\":" << (cap_exit ? "true" : "false")
+              << ",\"localVariables\":" << (cap_locals ? "true" : "false")
+              << ",\"exceptions\":" << (cap_exc ? "true" : "false")
+              << ",\"enabledEvents\":" << esc(enabled_events.c_str());
+        emit_gap("reduced-live-capabilities", pname,
+                 "live attach obtained only a subset of JVMTI capabilities; "
+                 "entry/exit, local-variable, and exception events unavailable "
+                 "in this phase are not enabled and will not appear in the trace. "
+                 "For full method-body recovery use the startup -agentpath path.",
+                 extra.str());
     }
 
     jvmtiEventCallbacks cbs{};
@@ -415,7 +453,7 @@ jint init_agent(JavaVM* vm, char* options, bool live_attach) {
     }
 
     if (live_attach) {
-        install_on_live_threads(vm, jvmti, pname);
+        install_on_live_threads(vm, jvmti, pname, enabled_events);
     }
 
     return JNI_OK;

--- a/native/src/jni_hook.cpp
+++ b/native/src/jni_hook.cpp
@@ -59,6 +59,10 @@ thread_local const char* t_current_method = nullptr;
 // Configurable via the `max-frame-events=N` agent option; 0 = unlimited.
 int g_max_frame_events = 50000;
 
+// When true, JNI-call wrappers emit even when not inside a user native frame.
+// Wired to the `log-all=true` agent option (see set_log_all). Off by default.
+std::atomic<bool> g_log_all{false};
+
 // Parse a method descriptor into a list of arg-type tokens.
 // Example: "(ILjava/lang/String;[I)V" -> ["I", "Ljava/lang/String;", "[I"].
 std::vector<std::string> parse_arg_types(const std::string& desc) {
@@ -235,8 +239,15 @@ std::string hex_ptr(const void* p) {
 
 void emit(const std::string& call, const std::string& args, const std::string& ret,
           jmethodID mid = nullptr, const std::string& ret_str = std::string()) {
-    if (!in_native_frame() || t_suppress_depth > 0) return;
-    if (g_max_frame_events > 0 && t_frame_event_count >= g_max_frame_events) {
+    if (t_suppress_depth > 0) return;
+    const bool inframe = in_native_frame();
+    // Outside a user native frame we normally stay silent (those JNI calls are
+    // noise for recovery). The `log-all` agent option opts into logging them.
+    if (!inframe && !g_log_all.load(std::memory_order_relaxed)) return;
+    // The per-frame event budget only applies inside a frame (the counter is
+    // reset on outermost frame entry); log-all events outside a frame are not
+    // budgeted here.
+    if (inframe && g_max_frame_events > 0 && t_frame_event_count >= g_max_frame_events) {
         if (!t_frame_truncated) {
             t_frame_truncated = true;
             // emit a single truncation marker once per frame
@@ -248,7 +259,7 @@ void emit(const std::string& call, const std::string& args, const std::string& r
         }
         return;
     }
-    ++t_frame_event_count;
+    if (inframe) ++t_frame_event_count;
     std::ostringstream os;
     os << "{\"ev\":\"jni\",\"ts\":" << TraceWriter::ts_now()
        << ",\"thr\":" << TraceWriter::tid()
@@ -397,7 +408,7 @@ std::string read_jstring(JNIEnv* env, jobject obj) {
 }
 
 void emit_propagate(const char* call, jobject from, jobject to) {
-    if (!in_native_frame()) return;
+    if (!in_native_frame() && !g_log_all.load(std::memory_order_relaxed)) return;
     std::ostringstream os;
     os << "{\"ev\":\"jni\",\"ts\":" << TraceWriter::ts_now()
        << ",\"thr\":" << TraceWriter::tid()
@@ -1062,6 +1073,9 @@ void exit_native_frame()  { if (t_frame_depth > 0) --t_frame_depth; }
 bool in_native_frame()    { return t_frame_depth > 0; }
 
 void set_max_frame_events(int n) { g_max_frame_events = n; }
+
+void set_log_all(bool on) { g_log_all.store(on, std::memory_order_relaxed); }
+bool log_all() { return g_log_all.load(std::memory_order_relaxed); }
 
 void enter_suppress_frame() { ++t_suppress_depth; }
 void exit_suppress_frame()  { if (t_suppress_depth > 0) --t_suppress_depth; }

--- a/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
@@ -37,6 +37,10 @@ class ValidationResult:
     ok: bool
     problems: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    # Structured refusals for the cases that have a stable reason code
+    # (cross-user, not-a-jvm) so the CLI can print the same
+    # ``attach failed (reason=<code>):`` form as every other refusal.
+    refusals: List["AttachRefusal"] = field(default_factory=list)
 
 
 def looks_like_java(comm: str, cmdline: List[str]) -> bool:
@@ -132,6 +136,7 @@ def validate_attach_target(
     """
     problems: List[str] = []
     warnings: List[str] = []
+    refusals: List[AttachRefusal] = []
 
     if pid <= 0:
         problems.append(f"pid must be a positive integer, got {pid}")
@@ -152,18 +157,38 @@ def validate_attach_target(
             "skipping the same-user check"
         )
     elif proc.uid != current:
-        problems.append(
+        msg = (
             f"pid {pid} is owned by uid {proc.uid}, not the current uid "
             f"{current}; attach is same-user only"
         )
+        problems.append(msg)
+        refusals.append(
+            AttachRefusal(
+                reason=REASON_CROSS_USER,
+                message=(
+                    f"{msg}. Run as the owning user; do not use elevated "
+                    "privileges to cross users."
+                ),
+            )
+        )
 
     if not looks_like_java(proc.comm, proc.cmdline):
-        problems.append(
+        msg = (
             f"pid {pid} does not look like a Java process "
             f"(comm={proc.comm!r}); refusing to attach"
         )
+        problems.append(msg)
+        refusals.append(
+            AttachRefusal(
+                reason=REASON_NOT_A_JVM,
+                message=msg,
+                recommend_startup=False,
+            )
+        )
 
-    return ValidationResult(ok=not problems, problems=problems, warnings=warnings)
+    return ValidationResult(
+        ok=not problems, problems=problems, warnings=warnings, refusals=refusals
+    )
 
 
 def build_agent_options(
@@ -269,7 +294,6 @@ def jcmd_load_error(returncode: int, output: str) -> Optional[str]:
 # Stable reason codes (kept intentionally short and machine-greppable).
 REASON_ATTACH_DISABLED = "attach-disabled"
 REASON_DYNAMIC_AGENT_DISABLED = "dynamic-agent-disabled"
-REASON_ALLOW_ATTACH_SELF_DISABLED = "allow-attach-self-disabled"
 REASON_NOT_A_JVM = "not-a-jvm"
 REASON_CROSS_USER = "cross-user"
 REASON_AGENT_ONATTACH_MISSING = "agent-onattach-missing"
@@ -319,6 +343,10 @@ def _allow_attach_self_disabled(cmdline: List[str]) -> bool:
     Java's ``Boolean.getBoolean`` treats only ``"true"`` (case-insensitively) as
     true, so any other value — most obviously ``false`` — disables it. We only
     flag the obvious explicit ``=false`` form the docs mention.
+
+    Note this property governs *self*-attach only (a JVM attaching to its own
+    process). It does **not** block an external, same-user attach from this CLI,
+    so it is surfaced as a warning, not a refusal.
     """
     for tok in cmdline:
         low = tok.lower()
@@ -337,11 +365,14 @@ def scan_cmdline_for_refusals(cmdline: List[str]) -> Optional[AttachRefusal]:
 
       * ``-XX:+DisableAttachMechanism``          -> ``attach-disabled``
       * ``-XX:-EnableDynamicAgentLoading``       -> ``dynamic-agent-disabled``
-      * ``-Djdk.attach.allowAttachSelf=false``   -> ``allow-attach-self-disabled``
 
     Returns the most severe matching refusal, or None if nothing was detected
     (which is not a guarantee the attach will succeed — the target may carry the
     flags in ``JAVA_TOOL_OPTIONS`` etc. that argv does not show).
+
+    ``-Djdk.attach.allowAttachSelf=false`` is deliberately **not** a refusal
+    here: it disables *self*-attach only and does not block this external,
+    same-user attach. See :func:`scan_cmdline_for_warnings`.
     """
     tokens = list(cmdline or [])
     joined = " ".join(tokens)
@@ -366,17 +397,25 @@ def scan_cmdline_for_refusals(cmdline: List[str]) -> Optional[AttachRefusal]:
             ),
         )
 
-    if _allow_attach_self_disabled(tokens):
-        return AttachRefusal(
-            reason=REASON_ALLOW_ATTACH_SELF_DISABLED,
-            message=(
-                "target sets jdk.attach.allowAttachSelf=false; self-attach is "
-                "disabled (this blocks a same-process attach — attach from a "
-                "separate process, or use the startup path)."
-            ),
-        )
-
     return None
+
+
+def scan_cmdline_for_warnings(cmdline: List[str]) -> List[str]:
+    """Non-fatal notes about a target's argv that do **not** block an attach.
+
+    ``jdk.attach.allowAttachSelf=false`` disables a JVM attaching to *itself*
+    only; an external, same-user attach from this CLI is unaffected. We surface
+    it as a warning and proceed, rather than refusing a valid target on the
+    strength of a flag that does not apply to us.
+    """
+    warnings: List[str] = []
+    if _allow_attach_self_disabled(list(cmdline or [])):
+        warnings.append(
+            "target sets jdk.attach.allowAttachSelf=false; this disables "
+            "self-attach only and does not block this external, same-user "
+            "attach — proceeding."
+        )
+    return warnings
 
 
 def classify_attach_error(

--- a/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
@@ -12,6 +12,7 @@ recovery path is still startup instrumentation via ``-agentpath``.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
@@ -177,3 +178,78 @@ def build_agent_options(
     if max_frame_events is not None:
         opts.append(f"max-frame-events={max_frame_events}")
     return ",".join(opts)
+
+
+# ---------------------------------------------------------------------------
+# jcmd JVMTI.agent_load helpers
+#
+# `jcmd <pid> JVMTI.agent_load <lib> <opts>` routes <opts> through the
+# diagnostic-command argument parser, which treats ``key=value`` tokens as its
+# *own* named arguments and, for a positional argument, keeps only the part
+# before ``=`` (dropping the value). A bare option string such as
+# ``trace=out.jsonl`` therefore reaches the agent as an empty trace path, the
+# agent returns JNI_ERR, and — critically — ``jcmd`` still exits 0, printing
+# ``return code: -1`` on stdout. Wrapping the option string in single quotes
+# makes the DCmd parser take it as one literal positional value, so the agent
+# receives the options intact. These helpers are typer-free so both the option
+# form and the return-code parsing are unit-testable without a live JVM.
+# ---------------------------------------------------------------------------
+
+_JCMD_RETURN_CODE_RE = re.compile(r"return code:\s*(-?\d+)", re.IGNORECASE)
+
+
+def jcmd_agent_option_arg(opts: str) -> str:
+    """Quote ``opts`` for ``jcmd JVMTI.agent_load`` so ``key=value`` survives.
+
+    The diagnostic-command parser only preserves an option string containing
+    ``=`` when it is a single-quoted literal. We refuse rather than silently
+    corrupt if the option string itself contains a single quote (paths with an
+    apostrophe are out of scope for this preview; use ``--mechanism vm``).
+    """
+    if "'" in opts:
+        raise ValueError(
+            "agent option string contains a single quote, which cannot be "
+            "passed safely through jcmd; use --mechanism vm instead"
+        )
+    return f"'{opts}'"
+
+
+def build_jcmd_agent_load_argv(
+    jcmd: str, pid: int, agent_path: str, opts: str
+) -> List[str]:
+    """Build the argv for ``jcmd <pid> JVMTI.agent_load <lib> '<opts>'``."""
+    argv = [jcmd, str(pid), "JVMTI.agent_load", agent_path]
+    if opts:
+        argv.append(jcmd_agent_option_arg(opts))
+    return argv
+
+
+def parse_jcmd_return_code(output: str) -> Optional[int]:
+    """Return the agent's ``Agent_OnAttach`` code from jcmd output, or None.
+
+    ``jcmd JVMTI.agent_load`` prints ``return code: <N>`` where ``<N>`` is the
+    value ``Agent_OnAttach`` returned (0 == success). It reports this even when
+    the agent fails, while the ``jcmd`` process itself still exits 0.
+    """
+    match = None
+    for match in _JCMD_RETURN_CODE_RE.finditer(output or ""):
+        pass
+    return int(match.group(1)) if match else None
+
+
+def jcmd_load_error(returncode: int, output: str) -> Optional[str]:
+    """Return a human-readable failure reason, or None if the load succeeded.
+
+    Treats both a non-zero ``jcmd`` process exit and a non-zero agent
+    ``return code:`` as failures, so an agent that fails to initialize can never
+    be reported as a successful attach.
+    """
+    if returncode != 0:
+        return f"jcmd exited with status {returncode}"
+    agent_rc = parse_jcmd_return_code(output)
+    if agent_rc is not None and agent_rc != 0:
+        return (
+            f"agent Agent_OnAttach returned {agent_rc} "
+            "(load failed; see the target JVM's stderr for details)"
+        )
+    return None

--- a/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
@@ -253,3 +253,258 @@ def jcmd_load_error(returncode: int, output: str) -> Optional[str]:
             "(load failed; see the target JVM's stderr for details)"
         )
     return None
+
+
+# ---------------------------------------------------------------------------
+# Refusal / failure classification
+#
+# The point of these helpers is *honesty*: detect the common situations where a
+# live attach cannot happen (or already failed), map them to a small set of
+# stable reason codes, and hand the caller an explanation plus the honest next
+# step. None of this bypasses, hides, or patches anything on the target — the
+# recommended remedy is always to restart the target with startup
+# instrumentation (``-agentpath``), the default highest-fidelity recovery path.
+# ---------------------------------------------------------------------------
+
+# Stable reason codes (kept intentionally short and machine-greppable).
+REASON_ATTACH_DISABLED = "attach-disabled"
+REASON_DYNAMIC_AGENT_DISABLED = "dynamic-agent-disabled"
+REASON_ALLOW_ATTACH_SELF_DISABLED = "allow-attach-self-disabled"
+REASON_NOT_A_JVM = "not-a-jvm"
+REASON_CROSS_USER = "cross-user"
+REASON_AGENT_ONATTACH_MISSING = "agent-onattach-missing"
+REASON_AGENT_INIT_FAILED = "agent-init-failed"
+REASON_JCMD_FALSE_SUCCESS = "jcmd-false-success"
+REASON_UNKNOWN = "unknown"
+
+# The one honest remedy this tool offers for every refusal below. It does not
+# bypass the target's flags; it restarts the target under instrumentation.
+STARTUP_PATH_RECOMMENDATION = (
+    "Restart the target under startup instrumentation instead: "
+    "java -agentpath:<path-to-j2c_agent> ... (see `recover` / `dynamic-trace` "
+    "and docs/jvm-attach.md). This tool does not, and will not, bypass the "
+    "target JVM's own attach/agent flags."
+)
+
+# How much raw error text an `unknown` classification keeps for context.
+_UNKNOWN_SNIPPET_LIMIT = 400
+
+
+@dataclass
+class AttachRefusal:
+    """A classified reason a live attach will not / did not happen.
+
+    ``reason`` is one of the stable ``REASON_*`` codes; ``message`` explains it
+    for a human; ``detail`` optionally carries a (truncated) raw snippet for the
+    ``unknown`` case. ``recommend_startup`` is True for every case here — the
+    honest remedy is always the startup ``-agentpath`` path.
+    """
+
+    reason: str
+    message: str
+    detail: str = ""
+    recommend_startup: bool = True
+
+
+def _truncate(text: str, limit: int = _UNKNOWN_SNIPPET_LIMIT) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + " …[truncated]"
+
+
+def _allow_attach_self_disabled(cmdline: List[str]) -> bool:
+    """True if argv sets ``jdk.attach.allowAttachSelf`` to a false-y value.
+
+    Java's ``Boolean.getBoolean`` treats only ``"true"`` (case-insensitively) as
+    true, so any other value — most obviously ``false`` — disables it. We only
+    flag the obvious explicit ``=false`` form the docs mention.
+    """
+    for tok in cmdline:
+        low = tok.lower()
+        if "jdk.attach.allowattachself=" in low:
+            value = low.split("jdk.attach.allowattachself=", 1)[1]
+            if value != "true":
+                return True
+    return False
+
+
+def scan_cmdline_for_refusals(cmdline: List[str]) -> Optional[AttachRefusal]:
+    """Scan a target's argv for flags that make a live attach fail/refused.
+
+    Runs *before* jcmd/VirtualMachine is invoked so the CLI can classify and
+    refuse cleanly instead of surfacing an opaque attach-layer error. Detects:
+
+      * ``-XX:+DisableAttachMechanism``          -> ``attach-disabled``
+      * ``-XX:-EnableDynamicAgentLoading``       -> ``dynamic-agent-disabled``
+      * ``-Djdk.attach.allowAttachSelf=false``   -> ``allow-attach-self-disabled``
+
+    Returns the most severe matching refusal, or None if nothing was detected
+    (which is not a guarantee the attach will succeed — the target may carry the
+    flags in ``JAVA_TOOL_OPTIONS`` etc. that argv does not show).
+    """
+    tokens = list(cmdline or [])
+    joined = " ".join(tokens)
+
+    if "-XX:+DisableAttachMechanism" in joined:
+        return AttachRefusal(
+            reason=REASON_ATTACH_DISABLED,
+            message=(
+                "target was started with -XX:+DisableAttachMechanism; the JVM "
+                "attach handshake is disabled, so no agent can be loaded into "
+                "this live process."
+            ),
+        )
+
+    if "-XX:-EnableDynamicAgentLoading" in joined:
+        return AttachRefusal(
+            reason=REASON_DYNAMIC_AGENT_DISABLED,
+            message=(
+                "target was started with -XX:-EnableDynamicAgentLoading; "
+                "dynamically loading a JVMTI agent into this live process is "
+                "disallowed."
+            ),
+        )
+
+    if _allow_attach_self_disabled(tokens):
+        return AttachRefusal(
+            reason=REASON_ALLOW_ATTACH_SELF_DISABLED,
+            message=(
+                "target sets jdk.attach.allowAttachSelf=false; self-attach is "
+                "disabled (this blocks a same-process attach — attach from a "
+                "separate process, or use the startup path)."
+            ),
+        )
+
+    return None
+
+
+def classify_attach_error(
+    returncode: int, output: str, agent_return_code: Optional[int] = None
+) -> AttachRefusal:
+    """Map a jcmd / VirtualMachine attach failure to a stable reason code.
+
+    ``returncode`` is the launcher process exit status, ``output`` its combined
+    stdout+stderr, and ``agent_return_code`` (if known) the value
+    ``Agent_OnAttach`` returned as parsed from jcmd output. This is a pure text
+    classifier — it never spawns a JVM — so callers can unit-test it directly.
+    Unrecognized failures return ``unknown`` with a truncated raw snippet.
+    """
+    text = output or ""
+    low = text.lower()
+
+    # Attach mechanism / handshake unavailable.
+    if (
+        "disableattachmechanism" in low
+        or "attach mechanism is disabled" in low
+        or "attachnotsupportedexception" in low
+        or "unable to open socket file" in low
+        or "the attach listener" in low
+        or "doesn't respond within" in low
+    ):
+        return AttachRefusal(
+            reason=REASON_ATTACH_DISABLED,
+            message=(
+                "the JVM attach mechanism is unavailable on the target "
+                "(commonly -XX:+DisableAttachMechanism or a stale/rejected "
+                "attach socket); no agent could be loaded."
+            ),
+            detail=_truncate(text),
+        )
+
+    # Dynamic agent loading disabled.
+    if (
+        "enabledynamicagentloading" in low
+        or "dynamic agent loading is not enabled" in low
+        or "dynamic loading of agents" in low
+    ):
+        return AttachRefusal(
+            reason=REASON_DYNAMIC_AGENT_DISABLED,
+            message=(
+                "dynamic agent loading is disabled on the target "
+                "(-XX:-EnableDynamicAgentLoading); the agent cannot be attached "
+                "to this live process."
+            ),
+            detail=_truncate(text),
+        )
+
+    # Cross-user / permission refusal from the attach layer.
+    if (
+        "operation not permitted" in low
+        or "well-known file is not secure" in low
+        or "not owned by the current user" in low
+        or ("permission denied" in low and "socket" in low)
+    ):
+        return AttachRefusal(
+            reason=REASON_CROSS_USER,
+            message=(
+                "the attach layer refused for permission / ownership reasons; "
+                "attach is same-user only — run as the owning user, do not use "
+                "elevated privileges to cross users."
+            ),
+            detail=_truncate(text),
+        )
+
+    # Agent library present but does not export Agent_OnAttach. Match only the
+    # "missing export" phrasings, not any mention of Agent_OnAttach (an init
+    # *failure* also names it and is classified separately below).
+    if (
+        "does not have agent_onattach" in low
+        or "no agent_onattach" in low
+        or "failed to find agent_onattach" in low
+        or "agent_onattach not found" in low
+        or "can't find agent_onattach" in low
+        or "cannot find agent_onattach" in low
+    ):
+        return AttachRefusal(
+            reason=REASON_AGENT_ONATTACH_MISSING,
+            message=(
+                "the agent library does not export Agent_OnAttach, so it cannot "
+                "be loaded into a live VM; rebuild the current native/ sources, "
+                "which export it (nm -D ... | grep Agent_On)."
+            ),
+            detail=_truncate(text),
+        )
+
+    # jcmd's false success: process exit 0 but Agent_OnAttach returned non-zero.
+    if returncode == 0 and agent_return_code is not None and agent_return_code != 0:
+        return AttachRefusal(
+            reason=REASON_JCMD_FALSE_SUCCESS,
+            message=(
+                f"jcmd exited 0 but Agent_OnAttach returned {agent_return_code}; "
+                "the agent did not initialize (this is a failure, not a "
+                "successful attach)."
+            ),
+            detail=_truncate(text),
+        )
+
+    # Agent reached Agent_OnAttach but initialization failed.
+    if (
+        "agentinitializationexception" in low
+        or "agent_onattach failed" in low
+        or "the agent library failed to init" in low
+        or (agent_return_code is not None and agent_return_code != 0)
+    ):
+        rc = (
+            f" (Agent_OnAttach returned {agent_return_code})"
+            if agent_return_code is not None
+            else ""
+        )
+        return AttachRefusal(
+            reason=REASON_AGENT_INIT_FAILED,
+            message=(
+                f"the agent reached Agent_OnAttach but failed to initialize{rc}; "
+                "see the target JVM's stderr for the agent's own diagnostics."
+            ),
+            detail=_truncate(text),
+        )
+
+    return AttachRefusal(
+        reason=REASON_UNKNOWN,
+        message=(
+            f"attach failed and the error was not recognized "
+            f"(launcher exit status {returncode}); treating as a failure, not a "
+            "successful attach."
+        ),
+        detail=_truncate(text),
+    )

--- a/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/attach_support.py
@@ -1,0 +1,179 @@
+"""Support helpers for the opt-in live process-attach path.
+
+Deliberately free of ``typer`` / ``rich`` imports so the PID and same-user
+validation logic can be unit-tested without the CLI framework installed, and so
+it can be reused headless.
+
+Scope reminder: process attach is a *preview* diagnostic path for JVMs the
+current user owns or may inspect (same user only). The default, highest-fidelity
+recovery path is still startup instrumentation via ``-agentpath``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+# Explicit confirmation the caller must pass to proceed with an attach.
+CONFIRM_FLAG = "--i-own-this-process"
+
+
+@dataclass
+class ProcInfo:
+    """A best-effort snapshot of a target process."""
+
+    pid: int
+    exists: bool
+    uid: Optional[int] = None       # owning uid, or None if it can't be read
+    comm: str = ""                  # short command name (e.g. "java")
+    cmdline: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    problems: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+def looks_like_java(comm: str, cmdline: List[str]) -> bool:
+    """Best-effort test for whether a process looks like a JVM.
+
+    Accepts when ``java`` appears in the short command name or the basename of
+    ``argv[0]``, or when the argument vector carries an unmistakable JVM launch
+    signature (``-jar``, a ``.jar`` argument, ``-XX:`` / ``-D`` / ``-javaagent``
+    flags). Intentionally permissive but not blind: this is a guardrail, not an
+    authorization check — the explicit confirmation flag is the real gate.
+    """
+    comm_l = (comm or "").lower()
+    if "java" in comm_l:
+        return True
+    if cmdline:
+        exe = os.path.basename(cmdline[0]).lower()
+        if "java" in exe:
+            return True
+    joined = " ".join(cmdline).lower()
+    if (
+        " -jar" in f" {joined}"
+        or joined.endswith(".jar")
+        or "-xx:" in joined
+        or "-javaagent" in joined
+        or "-agentpath" in joined
+    ):
+        return True
+    return False
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — the same-user check will catch it.
+        return True
+    except (OSError, AttributeError):
+        # AttributeError: platform without os.kill; treat as unknown-but-present.
+        return True
+    return True
+
+
+def current_uid() -> Optional[int]:
+    """The current user's uid, or None on platforms without ``os.getuid``."""
+    getuid = getattr(os, "getuid", None)
+    return getuid() if getuid is not None else None
+
+
+def read_proc_info(pid: int) -> ProcInfo:
+    """Read a best-effort snapshot of ``pid``.
+
+    On Linux this reads ``/proc/<pid>/{comm,cmdline}`` and the owning uid via
+    ``stat``. On platforms without procfs it falls back to a liveness probe and
+    leaves ``uid``/``comm``/``cmdline`` empty (callers should degrade to
+    warnings, not hard failures, for the fields it can't fill).
+    """
+    proc = Path("/proc") / str(pid)
+    if proc.exists():
+        uid: Optional[int] = None
+        try:
+            uid = proc.stat().st_uid
+        except OSError:
+            uid = None
+        comm = ""
+        try:
+            comm = (proc / "comm").read_text(errors="replace").strip()
+        except OSError:
+            pass
+        cmdline: List[str] = []
+        try:
+            raw = (proc / "cmdline").read_bytes()
+            cmdline = [p.decode("utf-8", "replace") for p in raw.split(b"\x00") if p]
+        except OSError:
+            pass
+        return ProcInfo(pid=pid, exists=True, uid=uid, comm=comm, cmdline=cmdline)
+    return ProcInfo(pid=pid, exists=_pid_alive(pid))
+
+
+def validate_attach_target(
+    pid: int,
+    proc: ProcInfo,
+    current: Optional[int],
+) -> ValidationResult:
+    """Validate that ``pid`` is a same-user Java process worth attaching to.
+
+    Hard failures (``problems``): non-positive pid, process not running, or a
+    clear cross-user / non-Java mismatch. Soft, best-effort gaps (``warnings``):
+    an owner or current uid we couldn't determine.
+    """
+    problems: List[str] = []
+    warnings: List[str] = []
+
+    if pid <= 0:
+        problems.append(f"pid must be a positive integer, got {pid}")
+        return ValidationResult(ok=False, problems=problems, warnings=warnings)
+
+    if not proc.exists:
+        problems.append(f"no process with pid {pid} is running")
+        return ValidationResult(ok=False, problems=problems, warnings=warnings)
+
+    if current is None:
+        warnings.append(
+            "cannot determine the current uid on this platform; "
+            "skipping the same-user check"
+        )
+    elif proc.uid is None:
+        warnings.append(
+            f"cannot determine the owner uid of pid {pid}; "
+            "skipping the same-user check"
+        )
+    elif proc.uid != current:
+        problems.append(
+            f"pid {pid} is owned by uid {proc.uid}, not the current uid "
+            f"{current}; attach is same-user only"
+        )
+
+    if not looks_like_java(proc.comm, proc.cmdline):
+        problems.append(
+            f"pid {pid} does not look like a Java process "
+            f"(comm={proc.comm!r}); refusing to attach"
+        )
+
+    return ValidationResult(ok=not problems, problems=problems, warnings=warnings)
+
+
+def build_agent_options(
+    output: str,
+    log_all: bool = False,
+    max_frame_events: Optional[int] = None,
+) -> str:
+    """Assemble the ``key=value,...`` option string the agent parses."""
+    opts = [f"trace={output}"]
+    if log_all:
+        opts.append("log-all=true")
+    if max_frame_events is not None:
+        opts.append(f"max-frame-events={max_frame_events}")
+    return ",".join(opts)

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -18,7 +18,9 @@ from rich.console import Console
 from .attach_support import (
     CONFIRM_FLAG,
     build_agent_options,
+    build_jcmd_agent_load_argv,
     current_uid,
+    jcmd_load_error,
     read_proc_info,
     validate_attach_target,
 )
@@ -123,9 +125,25 @@ def _jdk_tool(name: str) -> str:
 
 def _attach_via_jcmd(pid: int, agent_path: Path, opts: str) -> None:
     """Attach via `jcmd <pid> JVMTI.agent_load` (documented diagnostic command,
-    routed through the same attach mechanism, invokes Agent_OnAttach)."""
+    routed through the same attach mechanism, invokes Agent_OnAttach).
+
+    Two subtleties make a naive invocation report false success:
+      * the diagnostic-command parser strips the value from a bare ``key=value``
+        agent option, so the option string must be passed single-quoted; and
+      * ``jcmd`` exits 0 even when ``Agent_OnAttach`` fails, printing
+        ``return code: <N>`` on stdout — so we parse that and fail loudly.
+    """
     jcmd = _jdk_tool("jcmd")
-    run([jcmd, str(pid), "JVMTI.agent_load", str(agent_path), opts])
+    argv = build_jcmd_agent_load_argv(jcmd, pid, str(agent_path), opts)
+    console.log(f"[dim]$ {' '.join(argv)}[/]")
+    res = subprocess.run(argv, check=False, capture_output=True, text=True)
+    combined = f"{res.stdout}{res.stderr}"
+    if combined.strip():
+        console.log(combined.rstrip())
+    error = jcmd_load_error(res.returncode, combined)
+    if error:
+        console.print(f"[red]error:[/] jcmd agent load failed: {error}")
+        raise typer.Exit(code=1)
 
 
 def _attach_via_vm(pid: int, agent_path: Path, opts: str) -> None:
@@ -151,12 +169,14 @@ def _do_attach(pid: int, agent_path: Path, opts: str, mechanism: str) -> None:
         raise typer.BadParameter(
             f"unknown --mechanism {mechanism!r}; choose auto | jcmd | vm"
         )
-    # auto: prefer jcmd (no compile step); fall back to the VirtualMachine helper.
+    # auto: prefer jcmd (no compile step); fall back to the VirtualMachine helper
+    # only when jcmd itself is unavailable. A genuine agent-load failure must
+    # propagate (not silently trigger a second attempt that reloads the agent).
     try:
         _attach_via_jcmd(pid, agent_path, opts)
-    except (FileNotFoundError, typer.Exit) as exc:
+    except FileNotFoundError as exc:
         console.log(
-            f"[yellow]jcmd attach unavailable ({exc!r}); "
+            f"[yellow]jcmd unavailable ({exc!r}); "
             "falling back to com.sun.tools.attach[/]"
         )
         _attach_via_vm(pid, agent_path, opts)
@@ -410,9 +430,12 @@ def cli_attach(
     Opt-in diagnostic path — NOT the default recover flow. The default,
     highest-fidelity path is still startup instrumentation via -agentpath
     (see `recover` / `dynamic-trace`). Live attach only observes work that
-    happens after attach, and per-JNI-call argument capture is limited to
-    threads started after attach; already-running threads still emit
-    bind/enter/exit/exception events. See docs/jvm-attach.md.
+    happens after attach. Coverage depends on which JVMTI capabilities the JDK
+    grants after attach: on OpenJDK 21 typically only native-method-bind is
+    available, so the trace holds `bind` events and method entry/exit,
+    local-variable, and exception events are NOT captured. The trace's
+    `capability` / `gap` records state exactly what was obtained. See
+    docs/jvm-attach.md.
     """
     # 1. Refuse before touching the target unless ownership is confirmed.
     if not i_own_this_process:

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -17,11 +17,16 @@ from rich.console import Console
 
 from .attach_support import (
     CONFIRM_FLAG,
+    STARTUP_PATH_RECOMMENDATION,
+    AttachRefusal,
     build_agent_options,
     build_jcmd_agent_load_argv,
+    classify_attach_error,
     current_uid,
     jcmd_load_error,
+    parse_jcmd_return_code,
     read_proc_info,
+    scan_cmdline_for_refusals,
     validate_attach_target,
 )
 
@@ -123,6 +128,22 @@ def _jdk_tool(name: str) -> str:
     )
 
 
+def _report_refusal(refusal: AttachRefusal) -> None:
+    """Print a classified attach refusal/failure and exit non-zero.
+
+    Never prints ``attached``: reaching here means the attach did not happen.
+    """
+    console.print(
+        f"[red]error:[/] attach failed (reason={refusal.reason}): "
+        f"{refusal.message}"
+    )
+    if refusal.detail:
+        console.print(f"[dim]target output: {refusal.detail}[/]")
+    if refusal.recommend_startup:
+        console.print(f"[yellow]next step:[/] {STARTUP_PATH_RECOMMENDATION}")
+    raise typer.Exit(code=1)
+
+
 def _attach_via_jcmd(pid: int, agent_path: Path, opts: str) -> None:
     """Attach via `jcmd <pid> JVMTI.agent_load` (documented diagnostic command,
     routed through the same attach mechanism, invokes Agent_OnAttach).
@@ -132,6 +153,9 @@ def _attach_via_jcmd(pid: int, agent_path: Path, opts: str) -> None:
         agent option, so the option string must be passed single-quoted; and
       * ``jcmd`` exits 0 even when ``Agent_OnAttach`` fails, printing
         ``return code: <N>`` on stdout — so we parse that and fail loudly.
+
+    On any failure the error is classified into a stable reason code and the
+    honest next step (startup ``-agentpath``) is printed.
     """
     jcmd = _jdk_tool("jcmd")
     argv = build_jcmd_agent_load_argv(jcmd, pid, str(agent_path), opts)
@@ -142,19 +166,35 @@ def _attach_via_jcmd(pid: int, agent_path: Path, opts: str) -> None:
         console.log(combined.rstrip())
     error = jcmd_load_error(res.returncode, combined)
     if error:
-        console.print(f"[red]error:[/] jcmd agent load failed: {error}")
-        raise typer.Exit(code=1)
+        refusal = classify_attach_error(
+            res.returncode, combined, parse_jcmd_return_code(combined)
+        )
+        _report_refusal(refusal)
 
 
 def _attach_via_vm(pid: int, agent_path: Path, opts: str) -> None:
-    """Attach via com.sun.tools.attach.VirtualMachine using a compiled helper."""
+    """Attach via com.sun.tools.attach.VirtualMachine using a compiled helper.
+
+    The compile step is a local-toolchain concern (surfaced by ``run``); the
+    attach invocation itself captures output so a failure is classified into a
+    stable reason code rather than an opaque Java stack trace.
+    """
     javac = _jdk_tool("javac")
     java = _jdk_tool("java")
     helper_dir = Path(tempfile.mkdtemp(prefix="j2c-attach-"))
     src = helper_dir / "J2cAttach.java"
     src.write_text(_ATTACH_HELPER_SOURCE)
     run([javac, "-d", str(helper_dir), str(src)])
-    run([java, "-cp", str(helper_dir), "J2cAttach", str(pid), str(agent_path), opts])
+    argv = [java, "-cp", str(helper_dir), "J2cAttach", str(pid), str(agent_path), opts]
+    console.log(f"[dim]$ {' '.join(str(x) for x in argv)}[/]")
+    res = subprocess.run([str(x) for x in argv], check=False,
+                         capture_output=True, text=True)
+    combined = f"{res.stdout}{res.stderr}"
+    if combined.strip():
+        console.log(combined.rstrip())
+    if res.returncode != 0:
+        refusal = classify_attach_error(res.returncode, combined)
+        _report_refusal(refusal)
 
 
 def _do_attach(pid: int, agent_path: Path, opts: str, mechanism: str) -> None:
@@ -457,6 +497,14 @@ def cli_attach(
             console.print(f"[red]error:[/] {problem}")
         raise typer.Exit(code=2)
 
+    # 2b. Pre-attach cmdline scan: if the target's own argv shows the attach or
+    # dynamic-agent-loading mechanism is disabled, classify and refuse *before*
+    # invoking jcmd/VirtualMachine. This is honest handling, not a bypass: the
+    # remedy is to restart under startup instrumentation.
+    refusal = scan_cmdline_for_refusals(proc.cmdline)
+    if refusal is not None:
+        _report_refusal(refusal)
+
     # 3. Resolve the agent library.
     if agent is not None:
         agent_path = agent
@@ -480,6 +528,15 @@ def cli_attach(
         f"[bold green]attached (preview).[/] trace -> {output}\n"
         "Clean stop: terminate the target JVM normally; the agent flushes and "
         "closes the trace on VM exit. Then feed the trace to `trace-to-bc`."
+    )
+    # Reduced coverage is not a refusal: the attach happened. Remind the user
+    # that a live attach commonly obtains only native-method-bind (see the
+    # trace's capability/gap records) and full method-body recovery needs the
+    # startup -agentpath path.
+    console.print(
+        "[dim]note: a live attach commonly obtains only native-method-bind "
+        "coverage (see the trace's capability/gap records); for full "
+        "method-body recovery use the startup -agentpath path.[/]"
     )
 
 

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -15,6 +15,14 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from .attach_support import (
+    CONFIRM_FLAG,
+    build_agent_options,
+    current_uid,
+    read_proc_info,
+    validate_attach_target,
+)
+
 app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
@@ -69,6 +77,89 @@ def run(cmd: list[str | Path], **kwargs) -> subprocess.CompletedProcess:
     if res.returncode != 0:
         raise typer.Exit(code=res.returncode)
     return res
+
+
+# ------------------------------------------------------------------
+# Live process attach (opt-in preview) — mechanism helpers
+# ------------------------------------------------------------------
+
+# Minimal helper using the documented JDK attach API (com.sun.tools.attach).
+# Compiled on demand so the preview path doesn't need its own Gradle module.
+_ATTACH_HELPER_SOURCE = """\
+import com.sun.tools.attach.VirtualMachine;
+
+public class J2cAttach {
+    public static void main(String[] args) throws Exception {
+        String pid = args[0];
+        String path = args[1];
+        String opts = args.length > 2 ? args[2] : "";
+        VirtualMachine vm = VirtualMachine.attach(pid);
+        try {
+            vm.loadAgentPath(path, opts.isEmpty() ? null : opts);
+        } finally {
+            vm.detach();
+        }
+        System.out.println("j2c-attach: loaded " + path + " into pid " + pid);
+    }
+}
+"""
+
+
+def _jdk_tool(name: str) -> str:
+    """Locate a JDK command-line tool (java / javac / jcmd)."""
+    exe = f"{name}.exe" if os.name == "nt" else name
+    java_home = os.environ.get("JAVA_HOME") or os.environ.get("JDK_HOME")
+    if java_home:
+        candidate = Path(java_home) / "bin" / exe
+        if candidate.exists():
+            return str(candidate)
+    found = shutil.which(name)
+    if found:
+        return found
+    raise FileNotFoundError(
+        f"could not find '{name}'. Set JAVA_HOME or put the JDK bin/ on PATH."
+    )
+
+
+def _attach_via_jcmd(pid: int, agent_path: Path, opts: str) -> None:
+    """Attach via `jcmd <pid> JVMTI.agent_load` (documented diagnostic command,
+    routed through the same attach mechanism, invokes Agent_OnAttach)."""
+    jcmd = _jdk_tool("jcmd")
+    run([jcmd, str(pid), "JVMTI.agent_load", str(agent_path), opts])
+
+
+def _attach_via_vm(pid: int, agent_path: Path, opts: str) -> None:
+    """Attach via com.sun.tools.attach.VirtualMachine using a compiled helper."""
+    javac = _jdk_tool("javac")
+    java = _jdk_tool("java")
+    helper_dir = Path(tempfile.mkdtemp(prefix="j2c-attach-"))
+    src = helper_dir / "J2cAttach.java"
+    src.write_text(_ATTACH_HELPER_SOURCE)
+    run([javac, "-d", str(helper_dir), str(src)])
+    run([java, "-cp", str(helper_dir), "J2cAttach", str(pid), str(agent_path), opts])
+
+
+def _do_attach(pid: int, agent_path: Path, opts: str, mechanism: str) -> None:
+    mechanism = (mechanism or "auto").lower()
+    if mechanism == "jcmd":
+        _attach_via_jcmd(pid, agent_path, opts)
+        return
+    if mechanism == "vm":
+        _attach_via_vm(pid, agent_path, opts)
+        return
+    if mechanism != "auto":
+        raise typer.BadParameter(
+            f"unknown --mechanism {mechanism!r}; choose auto | jcmd | vm"
+        )
+    # auto: prefer jcmd (no compile step); fall back to the VirtualMachine helper.
+    try:
+        _attach_via_jcmd(pid, agent_path, opts)
+    except (FileNotFoundError, typer.Exit) as exc:
+        console.log(
+            f"[yellow]jcmd attach unavailable ({exc!r}); "
+            "falling back to com.sun.tools.attach[/]"
+        )
+        _attach_via_vm(pid, agent_path, opts)
 
 
 # ------------------------------------------------------------------
@@ -280,6 +371,93 @@ def recover(
     console.rule("[6/6] rebuild")
     _run_rebuild(jar, recovered_dir, output, manifest_json)
     console.print(f"[bold green]done:[/] {output}")
+
+
+@app.command("attach")
+def cli_attach(
+    pid: int = typer.Option(
+        ..., "--pid",
+        help="PID of the already-running, same-user JVM to attach to (required).",
+    ),
+    output: Path = typer.Option(
+        Path("trace.jsonl"), "-o", "--output",
+        help="Where the agent writes the JSONL trace.",
+    ),
+    i_own_this_process: bool = typer.Option(
+        False, "--i-own-this-process",
+        help="Required confirmation that you own or may inspect this JVM "
+             "(authorized, same-user use only).",
+    ),
+    agent: Optional[Path] = typer.Option(
+        None, "--agent",
+        help="Path to the built JVMTI agent (default: native/build/lib/j2c_agent.*).",
+    ),
+    log_all: bool = typer.Option(
+        False, "--log-all",
+        help="Log JNI calls even outside user native frames.",
+    ),
+    max_frame_events: Optional[int] = typer.Option(
+        None, "--max-frame-events",
+        help="Cap JNI events per native frame (0 = unlimited).",
+    ),
+    mechanism: str = typer.Option(
+        "auto", "--mechanism",
+        help="Attach mechanism: auto | jcmd | vm (com.sun.tools.attach).",
+    ),
+):
+    """(preview) Attach the JVMTI agent to an already-running JVM you own.
+
+    Opt-in diagnostic path — NOT the default recover flow. The default,
+    highest-fidelity path is still startup instrumentation via -agentpath
+    (see `recover` / `dynamic-trace`). Live attach only observes work that
+    happens after attach, and per-JNI-call argument capture is limited to
+    threads started after attach; already-running threads still emit
+    bind/enter/exit/exception events. See docs/jvm-attach.md.
+    """
+    # 1. Refuse before touching the target unless ownership is confirmed.
+    if not i_own_this_process:
+        console.print(
+            f"[red]refusing to attach without {CONFIRM_FLAG}.[/]\n"
+            "Live process attach is opt-in and for same-user, authorized use "
+            f"only. Re-run with {CONFIRM_FLAG} to confirm you own or may "
+            "inspect this JVM."
+        )
+        raise typer.Exit(code=2)
+
+    # 2. Best-effort same-user / looks-like-Java validation.
+    proc = read_proc_info(pid)
+    result = validate_attach_target(pid, proc, current_uid())
+    for warning in result.warnings:
+        console.print(f"[yellow]warning:[/] {warning}")
+    if not result.ok:
+        for problem in result.problems:
+            console.print(f"[red]error:[/] {problem}")
+        raise typer.Exit(code=2)
+
+    # 3. Resolve the agent library.
+    if agent is not None:
+        agent_path = agent
+        if not agent_path.exists():
+            console.print(f"[red]error:[/] agent not found: {agent_path}")
+            raise typer.Exit(code=2)
+    else:
+        try:
+            agent_path = native_lib()
+        except FileNotFoundError as exc:
+            console.print(f"[red]error:[/] {exc}")
+            raise typer.Exit(code=2)
+
+    opts = build_agent_options(str(output), log_all, max_frame_events)
+    console.print(
+        f"[cyan]attaching[/] agent={agent_path} pid={pid} "
+        f"(comm={proc.comm or '?'}) mechanism={mechanism}"
+    )
+    _do_attach(pid, agent_path, opts, mechanism)
+    console.print(
+        f"[bold green]attached (preview).[/] trace -> {output}\n"
+        "Clean stop: terminate the target JVM normally; the agent flushes and "
+        "closes the trace on VM exit. Then feed the trace to `trace-to-bc`."
+    )
 
 
 if __name__ == "__main__":

--- a/py/j2c_dumper_cli/j2c_dumper_cli/main.py
+++ b/py/j2c_dumper_cli/j2c_dumper_cli/main.py
@@ -27,6 +27,7 @@ from .attach_support import (
     parse_jcmd_return_code,
     read_proc_info,
     scan_cmdline_for_refusals,
+    scan_cmdline_for_warnings,
     validate_attach_target,
 )
 
@@ -493,11 +494,20 @@ def cli_attach(
     for warning in result.warnings:
         console.print(f"[yellow]warning:[/] {warning}")
     if not result.ok:
+        # cross-user / not-a-jvm carry a stable reason code: print the same
+        # `attach failed (reason=<code>):` form as every other refusal.
+        if result.refusals:
+            _report_refusal(result.refusals[0])
         for problem in result.problems:
             console.print(f"[red]error:[/] {problem}")
         raise typer.Exit(code=2)
 
-    # 2b. Pre-attach cmdline scan: if the target's own argv shows the attach or
+    # 2b. Non-fatal cmdline notes (e.g. jdk.attach.allowAttachSelf=false, which
+    # only disables self-attach and does not block this external attach).
+    for note in scan_cmdline_for_warnings(proc.cmdline):
+        console.print(f"[yellow]warning:[/] {note}")
+
+    # 2c. Pre-attach cmdline scan: if the target's own argv shows the attach or
     # dynamic-agent-loading mechanism is disabled, classify and refuse *before*
     # invoking jcmd/VirtualMachine. This is honest handling, not a bypass: the
     # remedy is to restart under startup instrumentation.

--- a/py/j2c_dumper_cli/tests/conftest.py
+++ b/py/j2c_dumper_cli/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Make the ``j2c_dumper_cli`` package importable when tests run without an
+editable install (e.g. plain ``pytest`` from a checkout)."""
+
+import pathlib
+import sys
+
+_PKG_PARENT = pathlib.Path(__file__).resolve().parents[1]
+if str(_PKG_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PKG_PARENT))

--- a/py/j2c_dumper_cli/tests/test_attach.py
+++ b/py/j2c_dumper_cli/tests/test_attach.py
@@ -223,12 +223,16 @@ def test_attach_requires_pid(runner, app):
 
 
 def test_attach_rejects_non_java_process(runner, app):
-    # Our own (Python) process: same uid, but not a JVM -> validation refuses.
+    # Our own (Python) process: same uid, but not a JVM -> validation refuses
+    # with the shared `attach failed (reason=not-a-jvm):` form (must-fix #2).
     result = runner.invoke(
         app, ["attach", "--pid", str(os.getpid()), "--i-own-this-process"]
     )
-    assert result.exit_code == 2
-    assert "does not look like a Java process" in _flat(result)
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "attach failed (reason=not-a-jvm)" in flat
+    assert "does not look like a Java process" in flat
+    assert "attached (preview)" not in result.output
 
 
 def test_attach_help_marks_preview_and_flag(runner, app):
@@ -357,18 +361,26 @@ def test_scan_does_not_flag_dynamic_agent_loading_enabled():
     ) is None
 
 
-def test_scan_detects_allow_attach_self_false():
-    r = A.scan_cmdline_for_refusals(
+def test_scan_does_not_refuse_allow_attach_self_false():
+    # allowAttachSelf=false disables *self*-attach only; it must NOT hard-refuse
+    # this external, same-user attach. It is surfaced as a warning instead.
+    assert A.scan_cmdline_for_refusals(
+        ["java", "-Djdk.attach.allowAttachSelf=false", "-jar", "app.jar"]
+    ) is None
+    warnings = A.scan_cmdline_for_warnings(
         ["java", "-Djdk.attach.allowAttachSelf=false", "-jar", "app.jar"]
     )
-    assert r is not None
-    assert r.reason == A.REASON_ALLOW_ATTACH_SELF_DISABLED
+    assert any("allowAttachSelf=false" in w for w in warnings)
+    assert any("self-attach only" in w for w in warnings)
 
 
 def test_scan_ignores_allow_attach_self_true():
     assert A.scan_cmdline_for_refusals(
         ["java", "-Djdk.attach.allowAttachSelf=true", "-jar", "app.jar"]
     ) is None
+    assert A.scan_cmdline_for_warnings(
+        ["java", "-Djdk.attach.allowAttachSelf=true", "-jar", "app.jar"]
+    ) == []
 
 
 def test_scan_priority_attach_disabled_first():
@@ -485,6 +497,74 @@ def test_attach_refuses_disable_attach_mechanism_before_jcmd(
     flat = _flat(result)
     assert "attach-disabled" in flat
     assert "attached (preview)" not in result.output
+
+
+def test_attach_cross_user_prints_reason_form(runner, app, monkeypatch, tmp_path):
+    """A cross-user target must print the shared
+    `attach failed (reason=cross-user):` form (must-fix #2), exit non-zero, and
+    never print 'attached (preview)'."""
+    from j2c_dumper_cli import main as M
+
+    agent = tmp_path / "j2c_agent.so"
+    agent.write_bytes(b"\x7fELF")
+
+    monkeypatch.setattr(M, "current_uid", lambda: 1000)
+    monkeypatch.setattr(
+        M, "read_proc_info",
+        lambda p: A.ProcInfo(
+            pid=p, exists=True, uid=4242, comm="java",
+            cmdline=["/usr/bin/java", "-jar", "app.jar"],
+        ),
+    )
+
+    def boom(*a, **k):
+        raise AssertionError("subprocess.run must not be called after refusal")
+
+    monkeypatch.setattr(M.subprocess, "run", boom)
+
+    result = runner.invoke(app, [
+        "attach", "--pid", "4321", "--i-own-this-process", "--agent", str(agent),
+    ])
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "attach failed (reason=cross-user)" in flat
+    assert "attached (preview)" not in result.output
+
+
+def test_attach_allow_attach_self_false_warns_but_proceeds(
+    runner, app, monkeypatch, tmp_path
+):
+    """allowAttachSelf=false disables *self*-attach only; an external same-user
+    attach must NOT be refused for it (must-fix #1). The CLI warns and proceeds
+    to a normal (here faked-successful) attach."""
+    from j2c_dumper_cli import main as M
+
+    agent = tmp_path / "j2c_agent.so"
+    agent.write_bytes(b"\x7fELF")
+
+    monkeypatch.setattr(M, "_jdk_tool", lambda name: name)
+    monkeypatch.setattr(
+        M, "read_proc_info",
+        lambda p: A.ProcInfo(
+            pid=p, exists=True, uid=None, comm="java",
+            cmdline=["/usr/bin/java", "-Djdk.attach.allowAttachSelf=false",
+                     "-jar", "app.jar"],
+        ),
+    )
+    monkeypatch.setattr(
+        M.subprocess, "run",
+        lambda *a, **k: _FakeCompleted(0, stdout="4321:\nreturn code: 0\n"),
+    )
+
+    result = runner.invoke(app, [
+        "attach", "--pid", "4321", "--i-own-this-process",
+        "--agent", str(agent), "--mechanism", "jcmd",
+    ])
+    assert result.exit_code == 0
+    flat = _flat(result)
+    assert "allowAttachSelf=false" in flat  # warned
+    assert "attach failed" not in flat      # not refused
+    assert "attached (preview)" in flat      # proceeded
 
 
 def test_attach_jcmd_failure_prints_reason_and_startup_path(

--- a/py/j2c_dumper_cli/tests/test_attach.py
+++ b/py/j2c_dumper_cli/tests/test_attach.py
@@ -318,3 +318,199 @@ def test_attach_jcmd_success_reports_attached(runner, app, monkeypatch, tmp_path
     ])
     assert result.exit_code == 0
     assert "attached (preview)" in _flat(result)
+    # Reduced coverage is not a refusal, but a one-line startup reminder is shown.
+    assert "startup -agentpath" in _flat(result)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: pre-attach cmdline scan (scan_cmdline_for_refusals)
+# ---------------------------------------------------------------------------
+
+def test_scan_clean_cmdline_returns_none():
+    assert A.scan_cmdline_for_refusals(
+        ["/usr/bin/java", "-Xmx1g", "-jar", "app.jar"]
+    ) is None
+    assert A.scan_cmdline_for_refusals([]) is None
+
+
+def test_scan_detects_disable_attach_mechanism():
+    r = A.scan_cmdline_for_refusals(
+        ["java", "-XX:+DisableAttachMechanism", "-jar", "app.jar"]
+    )
+    assert r is not None
+    assert r.reason == A.REASON_ATTACH_DISABLED
+    assert r.recommend_startup is True
+
+
+def test_scan_detects_dynamic_agent_loading_disabled():
+    r = A.scan_cmdline_for_refusals(
+        ["java", "-XX:-EnableDynamicAgentLoading", "-jar", "app.jar"]
+    )
+    assert r is not None
+    assert r.reason == A.REASON_DYNAMIC_AGENT_DISABLED
+
+
+def test_scan_does_not_flag_dynamic_agent_loading_enabled():
+    # The '+' (enabled) form must NOT be treated as a refusal.
+    assert A.scan_cmdline_for_refusals(
+        ["java", "-XX:+EnableDynamicAgentLoading", "-jar", "app.jar"]
+    ) is None
+
+
+def test_scan_detects_allow_attach_self_false():
+    r = A.scan_cmdline_for_refusals(
+        ["java", "-Djdk.attach.allowAttachSelf=false", "-jar", "app.jar"]
+    )
+    assert r is not None
+    assert r.reason == A.REASON_ALLOW_ATTACH_SELF_DISABLED
+
+
+def test_scan_ignores_allow_attach_self_true():
+    assert A.scan_cmdline_for_refusals(
+        ["java", "-Djdk.attach.allowAttachSelf=true", "-jar", "app.jar"]
+    ) is None
+
+
+def test_scan_priority_attach_disabled_first():
+    # If several blockers are present, the most fundamental one wins.
+    r = A.scan_cmdline_for_refusals([
+        "java",
+        "-XX:-EnableDynamicAgentLoading",
+        "-XX:+DisableAttachMechanism",
+        "-Djdk.attach.allowAttachSelf=false",
+    ])
+    assert r.reason == A.REASON_ATTACH_DISABLED
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: post-failure classification (classify_attach_error)
+# ---------------------------------------------------------------------------
+
+def test_classify_attach_disabled_from_output():
+    r = A.classify_attach_error(
+        1, "com.sun.tools.attach.AttachNotSupportedException: Unable to open "
+           "socket file: target process not responding",
+    )
+    assert r.reason == A.REASON_ATTACH_DISABLED
+    assert r.detail  # keeps a raw snippet
+
+
+def test_classify_dynamic_agent_disabled_from_output():
+    r = A.classify_attach_error(
+        1, "Dynamic agent loading is not enabled. "
+           "Use -XX:+EnableDynamicAgentLoading",
+    )
+    assert r.reason == A.REASON_DYNAMIC_AGENT_DISABLED
+
+
+def test_classify_cross_user_from_output():
+    r = A.classify_attach_error(
+        1, "java.io.IOException: well-known file is not secure: not owned by "
+           "the current user",
+    )
+    assert r.reason == A.REASON_CROSS_USER
+
+
+def test_classify_agent_onattach_missing():
+    r = A.classify_attach_error(
+        1, "The agent library does not have Agent_OnAttach and cannot be "
+           "loaded into a running VM",
+    )
+    assert r.reason == A.REASON_AGENT_ONATTACH_MISSING
+
+
+def test_classify_jcmd_false_success():
+    # jcmd process exit 0 but Agent_OnAttach returned -1.
+    r = A.classify_attach_error(0, "4321:\nreturn code: -1\n", agent_return_code=-1)
+    assert r.reason == A.REASON_JCMD_FALSE_SUCCESS
+    assert "-1" in r.message
+
+
+def test_classify_agent_init_failed():
+    r = A.classify_attach_error(
+        1, "com.sun.tools.attach.AgentInitializationException: "
+           "Agent_OnAttach failed",
+    )
+    assert r.reason == A.REASON_AGENT_INIT_FAILED
+
+
+def test_classify_agent_init_failed_from_nonzero_agent_rc():
+    r = A.classify_attach_error(1, "some java noise", agent_return_code=2)
+    assert r.reason == A.REASON_AGENT_INIT_FAILED
+
+
+def test_classify_unknown_keeps_truncated_snippet():
+    noise = "x" * 1000
+    r = A.classify_attach_error(3, noise)
+    assert r.reason == A.REASON_UNKNOWN
+    assert "truncated" in r.detail
+    assert len(r.detail) < len(noise)
+
+
+# ---------------------------------------------------------------------------
+# CLI-level: pre-attach cmdline scan refuses before invoking jcmd
+# ---------------------------------------------------------------------------
+
+def test_attach_refuses_disable_attach_mechanism_before_jcmd(
+    runner, app, monkeypatch, tmp_path
+):
+    """A target started with -XX:+DisableAttachMechanism must be refused with a
+    stable reason code *before* any attach subprocess runs, and must never print
+    'attached (preview)'."""
+    from j2c_dumper_cli import main as M
+
+    agent = tmp_path / "j2c_agent.so"
+    agent.write_bytes(b"\x7fELF")
+
+    monkeypatch.setattr(M, "_jdk_tool", lambda name: name)
+    monkeypatch.setattr(
+        M, "read_proc_info",
+        lambda p: A.ProcInfo(
+            pid=p, exists=True, uid=None, comm="java",
+            cmdline=["/usr/bin/java", "-XX:+DisableAttachMechanism",
+                     "-jar", "app.jar"],
+        ),
+    )
+
+    def boom(*a, **k):
+        raise AssertionError("subprocess.run must not be called after refusal")
+
+    monkeypatch.setattr(M.subprocess, "run", boom)
+
+    result = runner.invoke(app, [
+        "attach", "--pid", "4321", "--i-own-this-process",
+        "--agent", str(agent), "--mechanism", "jcmd",
+    ])
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "attach-disabled" in flat
+    assert "attached (preview)" not in result.output
+
+
+def test_attach_jcmd_failure_prints_reason_and_startup_path(
+    runner, app, monkeypatch, tmp_path
+):
+    """A post-failure jcmd error is classified and the startup path recommended;
+    'attached (preview)' is never printed."""
+    from j2c_dumper_cli import main as M
+
+    agent = tmp_path / "j2c_agent.so"
+    agent.write_bytes(b"\x7fELF")
+    _patch_attach_gate(monkeypatch, 4321, agent)
+
+    monkeypatch.setattr(
+        M.subprocess, "run",
+        lambda *a, **k: _FakeCompleted(
+            1, stderr="Dynamic agent loading is not enabled"
+        ),
+    )
+
+    result = runner.invoke(app, [
+        "attach", "--pid", "4321", "--i-own-this-process",
+        "--agent", str(agent), "--mechanism", "jcmd",
+    ])
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "dynamic-agent-disabled" in flat
+    assert "-agentpath" in flat
+    assert "attached (preview)" not in result.output

--- a/py/j2c_dumper_cli/tests/test_attach.py
+++ b/py/j2c_dumper_cli/tests/test_attach.py
@@ -1,0 +1,187 @@
+"""Tests for the opt-in live process-attach path.
+
+Covers:
+  * PID / same-user / looks-like-Java validation (pure helpers).
+  * The CLI refusing to proceed without the confirmation flag.
+  * `attach --help` / top-level help text.
+
+None of these start a JVM or actually attach: the CLI-level tests all fail the
+confirmation or validation gate before any attach is attempted, and the pure
+tests exercise the validation helpers directly.
+"""
+
+import os
+
+import pytest
+
+from j2c_dumper_cli import attach_support as A
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: looks_like_java
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "comm,cmdline,expected",
+    [
+        ("java", ["/usr/bin/java", "-jar", "app.jar"], True),
+        ("java", [], True),
+        ("openjdk", ["/opt/jdk/bin/javaw", "-Xmx1g", "-jar", "x.jar"], True),
+        ("wrapper", ["wrapper", "-jar", "app.jar"], True),
+        ("launcher", ["launcher", "-XX:+UseZGC", "MainClass"], True),
+        ("python3", ["python3", "script.py"], False),
+        ("bash", ["bash", "run.sh"], False),
+        ("node", ["node", "server.js"], False),
+    ],
+)
+def test_looks_like_java(comm, cmdline, expected):
+    assert A.looks_like_java(comm, cmdline) is expected
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: validate_attach_target
+# ---------------------------------------------------------------------------
+
+def _java_proc(pid=1234, uid=1000):
+    return A.ProcInfo(
+        pid=pid, exists=True, uid=uid, comm="java",
+        cmdline=["/usr/bin/java", "-jar", "app.jar"],
+    )
+
+
+def test_validate_rejects_non_positive_pid():
+    res = A.validate_attach_target(0, _java_proc(pid=0), current=1000)
+    assert not res.ok
+    assert any("positive" in p for p in res.problems)
+
+
+def test_validate_rejects_missing_process():
+    proc = A.ProcInfo(pid=4242, exists=False)
+    res = A.validate_attach_target(4242, proc, current=1000)
+    assert not res.ok
+    assert any("no process" in p for p in res.problems)
+
+
+def test_validate_rejects_cross_user():
+    proc = _java_proc(uid=1000)
+    res = A.validate_attach_target(1234, proc, current=1001)
+    assert not res.ok
+    assert any("same-user only" in p for p in res.problems)
+
+
+def test_validate_rejects_non_java():
+    proc = A.ProcInfo(
+        pid=1234, exists=True, uid=1000, comm="python3",
+        cmdline=["python3", "server.py"],
+    )
+    res = A.validate_attach_target(1234, proc, current=1000)
+    assert not res.ok
+    assert any("does not look like a Java process" in p for p in res.problems)
+
+
+def test_validate_accepts_same_user_java():
+    proc = _java_proc(uid=1000)
+    res = A.validate_attach_target(1234, proc, current=1000)
+    assert res.ok
+    assert res.problems == []
+
+
+def test_validate_warns_when_uid_unknown_but_still_ok():
+    proc = A.ProcInfo(
+        pid=1234, exists=True, uid=None, comm="java",
+        cmdline=["java", "-jar", "app.jar"],
+    )
+    res = A.validate_attach_target(1234, proc, current=1000)
+    assert res.ok
+    assert any("same-user check" in w for w in res.warnings)
+
+
+def test_validate_warns_when_current_uid_unknown():
+    proc = _java_proc(uid=1000)
+    res = A.validate_attach_target(1234, proc, current=None)
+    assert res.ok
+    assert any("current uid" in w for w in res.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: read_proc_info / build_agent_options
+# ---------------------------------------------------------------------------
+
+def test_read_proc_info_self():
+    info = A.read_proc_info(os.getpid())
+    assert info.exists
+    if hasattr(os, "getuid"):
+        assert info.uid == os.getuid()
+
+
+def test_read_proc_info_missing():
+    # A pid far above any plausible live process.
+    info = A.read_proc_info(2_147_480_000)
+    assert not info.exists
+
+
+def test_build_agent_options_minimal():
+    assert A.build_agent_options("trace.jsonl") == "trace=trace.jsonl"
+
+
+def test_build_agent_options_full():
+    got = A.build_agent_options("out/t.jsonl", log_all=True, max_frame_events=0)
+    assert got == "trace=out/t.jsonl,log-all=true,max-frame-events=0"
+
+
+# ---------------------------------------------------------------------------
+# CLI-level: refuse-without-flag / validation / help text
+# ---------------------------------------------------------------------------
+
+def _flat(result):
+    """Whitespace-normalized output (rich wraps lines at FORCED_WIDTH)."""
+    return " ".join(result.output.split())
+
+
+@pytest.fixture()
+def runner():
+    from typer.testing import CliRunner
+    return CliRunner()
+
+
+@pytest.fixture()
+def app():
+    from j2c_dumper_cli.main import app as _app
+    return _app
+
+
+def test_attach_refuses_without_confirmation_flag(runner, app):
+    # Huge pid that does not exist: proves the flag check happens *first*,
+    # before we probe the target at all.
+    result = runner.invoke(app, ["attach", "--pid", "4294967295"])
+    assert result.exit_code == 2
+    assert "own-this-process" in _flat(result)
+
+
+def test_attach_requires_pid(runner, app):
+    result = runner.invoke(app, ["attach", "--i-own-this-process"])
+    assert result.exit_code != 0
+
+
+def test_attach_rejects_non_java_process(runner, app):
+    # Our own (Python) process: same uid, but not a JVM -> validation refuses.
+    result = runner.invoke(
+        app, ["attach", "--pid", str(os.getpid()), "--i-own-this-process"]
+    )
+    assert result.exit_code == 2
+    assert "does not look like a Java process" in _flat(result)
+
+
+def test_attach_help_marks_preview_and_flag(runner, app):
+    result = runner.invoke(app, ["attach", "--help"])
+    assert result.exit_code == 0
+    flat = _flat(result)
+    assert "preview" in flat
+    assert "own-this-process" in flat
+    assert "--pid" in flat
+
+
+def test_top_level_help_lists_attach(runner, app):
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "attach" in _flat(result)

--- a/py/j2c_dumper_cli/tests/test_attach.py
+++ b/py/j2c_dumper_cli/tests/test_attach.py
@@ -130,6 +130,65 @@ def test_build_agent_options_full():
 
 
 # ---------------------------------------------------------------------------
+# jcmd option form + return-code parsing (regression for the false-success bug)
+# ---------------------------------------------------------------------------
+
+def test_jcmd_agent_option_is_single_quoted():
+    # A bare `trace=...,...` option makes jcmd's diagnostic-command parser drop
+    # the value; the option must be single-quoted so it reaches Agent_OnAttach
+    # intact. This test would have failed against the pre-fix (bare) form.
+    opts = "trace=out.jsonl,log-all=true,max-frame-events=0"
+    assert A.jcmd_agent_option_arg(opts) == "'trace=out.jsonl,log-all=true,max-frame-events=0'"
+
+
+def test_build_jcmd_argv_quotes_options():
+    argv = A.build_jcmd_agent_load_argv("jcmd", 4321, "/x/j2c_agent.so", "trace=t.jsonl")
+    assert argv == ["jcmd", "4321", "JVMTI.agent_load", "/x/j2c_agent.so", "'trace=t.jsonl'"]
+    # The option argument must be quoted (not bare) to survive DCmd parsing.
+    assert argv[-1].startswith("'") and argv[-1].endswith("'")
+
+
+def test_build_jcmd_argv_omits_empty_options():
+    argv = A.build_jcmd_agent_load_argv("jcmd", 1, "/x/a.so", "")
+    assert argv == ["jcmd", "1", "JVMTI.agent_load", "/x/a.so"]
+
+
+def test_jcmd_option_rejects_embedded_single_quote():
+    with pytest.raises(ValueError):
+        A.jcmd_agent_option_arg("trace=/tmp/it's/t.jsonl")
+
+
+def test_parse_jcmd_return_code_success():
+    assert A.parse_jcmd_return_code("4321:\nreturn code: 0\n") == 0
+
+
+def test_parse_jcmd_return_code_failure():
+    # This is exactly the false-success output: jcmd process exit 0 but the
+    # agent's Agent_OnAttach returned -1.
+    assert A.parse_jcmd_return_code("4321:\nreturn code: -1\n") == -1
+
+
+def test_parse_jcmd_return_code_absent():
+    assert A.parse_jcmd_return_code("some unrelated output") is None
+
+
+def test_jcmd_load_error_flags_agent_failure_despite_exit_zero():
+    # The core regression: jcmd exited 0, but the agent failed. Must be an error.
+    err = A.jcmd_load_error(0, "4321:\nreturn code: -1\n")
+    assert err is not None
+    assert "-1" in err
+
+
+def test_jcmd_load_error_none_on_success():
+    assert A.jcmd_load_error(0, "4321:\nreturn code: 0\n") is None
+
+
+def test_jcmd_load_error_flags_nonzero_process_exit():
+    err = A.jcmd_load_error(1, "java.lang.IllegalArgumentException: Unknown argument")
+    assert err is not None
+
+
+# ---------------------------------------------------------------------------
 # CLI-level: refuse-without-flag / validation / help text
 # ---------------------------------------------------------------------------
 
@@ -185,3 +244,77 @@ def test_top_level_help_lists_attach(runner, app):
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "attach" in _flat(result)
+
+
+# ---------------------------------------------------------------------------
+# CLI-level: jcmd false-success must become a hard failure (must-fix #1)
+# ---------------------------------------------------------------------------
+
+class _FakeCompleted:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _patch_attach_gate(monkeypatch, pid, agent_file):
+    """Get past the ownership/validation gate and agent resolution so the test
+    can exercise the actual jcmd invocation path."""
+    from j2c_dumper_cli import main as M
+
+    monkeypatch.setattr(M, "_jdk_tool", lambda name: name)
+    monkeypatch.setattr(
+        M, "read_proc_info",
+        lambda p: A.ProcInfo(pid=p, exists=True, uid=None, comm="java",
+                             cmdline=["/usr/bin/java", "-jar", "app.jar"]),
+    )
+
+
+def test_attach_jcmd_false_success_is_failure(runner, app, monkeypatch, tmp_path):
+    """jcmd exits 0 while Agent_OnAttach returned -1 -> CLI must fail, not
+    print 'attached'. This is the exact regression the review flagged."""
+    from j2c_dumper_cli import main as M
+
+    agent = tmp_path / "j2c_agent.so"
+    agent.write_bytes(b"\x7fELF")
+    _patch_attach_gate(monkeypatch, 4321, agent)
+
+    seen = {}
+
+    def fake_run(argv, check=False, capture_output=False, text=False):
+        seen["argv"] = argv
+        # Emulate jcmd's false success: process exit 0, agent return code -1.
+        return _FakeCompleted(0, stdout="4321:\nreturn code: -1\n")
+
+    monkeypatch.setattr(M.subprocess, "run", fake_run)
+
+    result = runner.invoke(app, [
+        "attach", "--pid", "4321", "--i-own-this-process",
+        "--agent", str(agent), "--mechanism", "jcmd",
+    ])
+    assert result.exit_code != 0
+    assert "attached (preview)" not in result.output
+    # And the options were passed single-quoted (would-be-corrupted otherwise).
+    opt_arg = seen["argv"][-1]
+    assert opt_arg.startswith("'") and opt_arg.endswith("'")
+    assert "trace=" in opt_arg
+
+
+def test_attach_jcmd_success_reports_attached(runner, app, monkeypatch, tmp_path):
+    from j2c_dumper_cli import main as M
+
+    agent = tmp_path / "j2c_agent.so"
+    agent.write_bytes(b"\x7fELF")
+    _patch_attach_gate(monkeypatch, 4321, agent)
+
+    monkeypatch.setattr(
+        M.subprocess, "run",
+        lambda *a, **k: _FakeCompleted(0, stdout="4321:\nreturn code: 0\n"),
+    )
+
+    result = runner.invoke(app, [
+        "attach", "--pid", "4321", "--i-own-this-process",
+        "--agent", str(agent), "--mechanism", "jcmd",
+    ])
+    assert result.exit_code == 0
+    assert "attached (preview)" in _flat(result)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
可选 JVMTI 运行中附加，并分类常见拒绝。独立复审：**ship-as-preview-draft**。两处诚实性 nit 已落到 `f7664e4`。

## (a) 本次改动范围
- `Agent_OnAttach`、所有权门禁、cmdline 预扫描、失败 reason code、capability/gap、文档。
- `allowAttachSelf=false` 只警告（自附加属性），不再误拒外部 CLI。
- `cross-user` / `not-a-jvm` 同样打印 `attach failed (reason=…)`。

## (b) 是否可直接上线
**可以合入开发预览，不能当默认功能。** OpenJDK 21 上常为 bind-only。无隐蔽、不绕过目标开关。

## (c) 上线前是否需要 review
预览标准已过。nit 已按复审改完。

## (d) review 的前置条件
- pytest attach 55 passed。
- 确认无隐蔽/绕过；`DisableAttachMechanism` / `EnableDynamicAgentLoading` 仍硬拒绝。

## 验证
- 分支：`cursor/opt-in-jvmti-live-attach-1155` @ `f7664e4`。
- PR：https://github.com/gaoyu06/c2j-native-deobfuscator/pull/9

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-459becce-9c8e-4f8a-87ec-4640ea985e25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459becce-9c8e-4f8a-87ec-4640ea985e25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

