### PR TITLE
docs: options and status report for platform work

### DIFF
--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -29,7 +29,7 @@ review can be skipped.
 |---:|---|---|---|
 | **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
-| **#4** | Generic-first discovery at `30775d85a0bfb0c8a553c1d3aa5019d4ec38b0a1`. In addition to the earlier format and architecture fixtures, committed fixtures now prove a shared-dispatch second registration family that recovers two tables from one `RegisterNatives` site, plus a genuine i386 ELF through the System V cdecl backend. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Architectures without a registered ABI backend and encrypted or shuffled tables remain unproven. |
+| **#4** | Generic-first discovery at `7643877759f2354b864908ae4c47a9a76764cfc8`. In addition to the earlier format and architecture fixtures, a committed genuine PE x86-64 DLL now makes the named `j2cc` detector fire on a real image, and a Microsoft x64 shared-dispatch harvest recovers two tables from one `RegisterNatives` site. The separate generic ELF shared-dispatch proof is unchanged. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Encrypted, runtime-decrypted, or shuffled tables and unregistered ABIs (MIPS, RISC-V, PE i386 stdcall) remain unproven. |
 | **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#6** | `doctor`, setup scripts, launchers, and getting-started material at `52ddeb3ed97a66316fce8be50d9242a71ce71ca0`. Offline discovery is documented as `parse-jar` + `inspect-binary` + `merge-manifest`, with Ghidra optional; `recover` still defaults to dynamic recovery. JDK 17 is retained. | **Yes: ship-as-draft.** | Normal merge review remains; neither a JDK migration nor an offline `recover` default is implied. |
 | **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `1817e2d664b0a72269f188cbc4a9ddc342b62f0a`. Linux smoke passes sections 1–15. Windows supports read-only module/export observation, with no live breakpoints. No kernel component is shipped. | **Yes: ship-as-preview-draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. |
@@ -45,7 +45,7 @@ review can be skipped.
 ### Generic-first discovery (#4)
 
 - The reviewed revision is
-  `30775d85a0bfb0c8a553c1d3aa5019d4ec38b0a1`.
+  `7643877759f2354b864908ae4c47a9a76764cfc8`.
 - Committed x86-64 fixtures exercise real PE, Mach-O, stripped ELF without
   `.symtab`, and exports-only ELF images.
 - Committed fixtures also exercise a real AArch64 ELF and a
@@ -55,22 +55,47 @@ review can be skipped.
 - A real Mach-O arm64 dylib now proves that format and architecture.
 - A committed real ELF32 ARM fixture and its tests now prove 32-bit ARM ELF
   discovery through the AAPCS32 backend.
-- A shared `initClass()`-style dispatcher proves a second registration family:
-  two independently sized tables are recovered from branches reaching one
-  `RegisterNatives` site instead of being collapsed into one silent binding.
 - A genuine i386 ELF fixture proves 32-bit x86 discovery through the System V
   cdecl backend, including stack arguments and GOT-relative table addressing.
+- `py/binary_introspect/tests/fixtures/jni_dispatch_j2cc.dll`, assembled from
+  the committed `jni_dispatch_j2cc.s`, is a genuine PE x86-64 image: it starts
+  with `MZ`, LIEF parses it as PE, its machine value is `0x8664`, and its
+  sha256 is
+  `6676142d1127ba8f9e4314a76f1d8a34db4695bfdf9fd317374c867d3312f563`.
+- The named `j2cc` detector now fires on that real DLL, reporting
+  `analysis.profile == "j2cc"`. Previously the named detector was proved only
+  against a mocked LIEF object.
+- On that fixture the `shared_dispatch` harvest on the Microsoft x64 backend
+  recovers two stack-built tables, with `nMethods` 2 and 3, from a single
+  `RegisterNatives` site at `0x1800010ef`; the reported abi is
+  `amd64-windows`, and the only `Java_*` exports are
+  `Java_com_example_Boot_initClass` and `Java_com_example_Boot_bootstrap`.
+- The existing `jni_registrar.dll` fixture still selects `generic`, so the
+  named detector is not being applied indiscriminately to PE images.
+- The ELF `libjni_dispatch_shared.so` fixture still proves the generic `auto`
+  shared-dispatch harvest with `profile=generic`. That proof and the new PE
+  `j2cc` proof are separate; neither replaces the other.
 - Ambiguous count-only matching is represented with `bindingGaps`; it is not
   silently treated as a complete binding, including for each shared-dispatch
   branch.
+- On the command line, `inspect-binary` prints `profile=` on stderr and
+  `merge-manifest` prints `bindingGaps=<n> kinds=…`. `bindingGaps` is a
+  reported count only; it is not written into `binary.json`.
+- Independently re-run `pytest` reports 31 passed for `binary_introspect`,
+  5 for `manifest_merge`, and 3 for `j2c_dumper_cli`.
 - The branch can **ship-as-draft-dev**.
-- The `recover` default is unchanged.
+- The `recover` default is unchanged; the branch shows no diff against `main`
+  for `recover` behavior.
 - It is not the default release path.
-- Architectures without a registered ABI backend, including 32-bit Windows
-  x86, and encrypted or shuffled tables remain unproven.
+- Encrypted or runtime-decrypted tables, shuffled tables, and architectures
+  without a registered ABI backend — including MIPS, RISC-V, and PE i386
+  stdcall — remain unproven.
 
 The consequence is deliberate: developers can continue validating the generic
 path without presenting incomplete platform coverage as a released default.
+Two reviewer nits are non-blocking: a split paragraph in
+`docs/generic-recovery.md`, and wording that describes `recover` as using the
+generic path when it in fact auto-detects with a generic fallback.
 
 ### Setup and launchers (#6)
 
@@ -200,7 +225,13 @@ the recommendation, and the consequence of adopting it.
 
 - The generic path is **not** the default release path.
 - Generic discovery does **not** cover architectures without a registered ABI
-  backend or encrypted or shuffled tables.
+  backend — including MIPS, RISC-V, and PE i386 stdcall — and does **not**
+  cover encrypted, runtime-decrypted, or shuffled tables.
+- A named `j2cc` profile on one real PE fixture does **not** make named-profile
+  detection general; the existing PE registrar fixture still resolves to
+  `generic`.
+- `bindingGaps` is **not** persisted in `binary.json`; it is reported by
+  `merge-manifest` on stderr.
 - Documenting the offline discovery sequence does **not** change `recover`;
   dynamic recovery remains its default.
 - Live attach is **not** equivalent to startup instrumentation and is often
@@ -233,10 +264,14 @@ the recommendation, and the consequence of adopting it.
 
 - #4 now has committed x86-64 PE, Mach-O, stripped-ELF-without-`.symtab`, and
   exports-only ELF fixtures, plus real AArch64 ELF, real ELF32 ARM, genuine
-  i386 ELF, section-header-removed ELF, and real Mach-O arm64 fixtures. Its
-  shared-dispatch fixture recovers two tables from one `RegisterNatives` site.
-  Default promotion remains blocked on evidence for architectures without a
-  registered ABI backend and encrypted or shuffled tables.
+  i386 ELF, section-header-removed ELF, and real Mach-O arm64 fixtures. A
+  genuine PE x86-64 DLL makes the named `j2cc` detector fire on a real image,
+  and its Microsoft x64 shared-dispatch harvest recovers two tables from one
+  `RegisterNatives` site; the ELF fixture separately proves the generic
+  shared-dispatch harvest. Default promotion remains blocked on evidence for
+  encrypted, runtime-decrypted, or shuffled tables and for architectures
+  without a registered ABI backend, including MIPS, RISC-V, and PE i386
+  stdcall.
 - #7 needs explicit plugin trust and transport decisions, additional platform
   evidence beyond Linux smoke sections 1–15 and Windows read-only module/export
   observation, and a separate promotion review before it can move beyond

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -34,7 +34,7 @@ review can be skipped.
 | **#6** | `doctor`, setup scripts, launchers, and getting-started material. JDK 17 is retained. | **Yes, as a draft.** | Normal merge review remains; no JDK migration is implied. |
 | **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `8b9231c145e80acbc723fbc893d072398cba143b`, after multiple must-fix rounds. | **Yes, as a preview draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. The current preview verdict is supported by the completed review rounds and smoke evidence. |
 | **#8** | Optional Swing + FlatLaf artifact viewer. The visual pass is complete. The desktop module uses JDK 21 while the repository baseline remains JDK 17. | **Yes, as an optional desktop draft.** | Yes, principally for the JDK 21 module boundary and normal merge review. |
-| **#9** | Opt-in JVMTI attach at `1a8cea87e8882fd48df8c00c5034021e23ccdaf3`. Common attach refusals are classified, there is no stealth or bypass behavior, and default recovery remains startup `-agentpath`. | **Yes: ship-as-preview-draft.** | Two review nits remain: `allowAttachSelf=false` governs self-attach and must not hard-refuse an external CLI, and pre-validation should print reason codes. Review remains required before capability or default-policy expansion. |
+| **#9** | Opt-in JVMTI attach at `f7664e46f89b83bc6ffb6c3680193412c8cbff36`. Common attach refusals are classified, there is no stealth or bypass behavior, and default recovery remains startup `-agentpath`. | **Yes: ship-as-preview-draft.** | `allowAttachSelf=false` warns rather than hard-refusing the external CLI; `cross-user` and `not-a-jvm` failures print `attach failed (reason=…)`; pytest reports 55 passed. Review remains required before capability or default-policy expansion. |
 | **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
 | **#11** | Optional privileged observer at `dc30188118a6579c024978fa9ff52ca154012170`, with a versioned plugin ABI and Linux maps backend. It is default-off userspace code with no kernel files. | **Yes: ship-as-preview-userspace.** | Yes for later promotion and merge-order integration with #7. It is not a kernel feature, and the default remains **no**. |
 | **#12** | Desktop live-attach/listen GUI, based on PR #8’s branch rather than `main`. Visual review is preview-ok. | **Yes, as a preview after #8.** | Yes for integration review after #8 and for the same attach limitations as #9. |
@@ -106,16 +106,16 @@ remain explicit rather than silently changing the repository baseline.
 ### JVMTI attach (#9)
 
 - The reviewed revision is
-  `1a8cea87e8882fd48df8c00c5034021e23ccdaf3`.
+  `f7664e46f89b83bc6ffb6c3680193412c8cbff36`.
 - Attach is opt-in and uses the existing same-user plus explicit confirmation
   policy.
 - Common attach refusals are classified.
 - There is no stealth or bypass behavior.
 - On OpenJDK 21, live attach is often bind-only.
 - Startup `-agentpath` remains the default recovery path.
-- Outstanding review nit: `allowAttachSelf=false` controls JVM self-attach; it
-  should not cause the external CLI to hard-refuse an attach attempt.
-- Outstanding review nit: pre-validation should print its reason codes.
+- `allowAttachSelf=false` warns and does not hard-refuse the external CLI.
+- `cross-user` and `not-a-jvm` failures print `attach failed (reason=…)`.
+- The test run reports `pytest`: 55 passed.
 
 The consequence is that attach can ship as a preview, but the GUI and CLI must
 display the capability actually obtained and must not imply startup-equivalent
@@ -185,8 +185,9 @@ the recommendation, and the consequence of adopting it.
 - #8/#12 must keep their JDK 21 requirement module-local unless the repository
   separately approves a baseline migration.
 - #9/#12 must report actual attach capabilities and retain startup `-agentpath`
-  as the default recovery path. #9 should also correct the `allowAttachSelf`
-  pre-check and print pre-validation reason codes.
+  as the default recovery path. #9 now warns for `allowAttachSelf=false` rather
+  than hard-refusing the external CLI, and prints reason codes for `cross-user`
+  and `not-a-jvm` failures.
 - #11 is a userspace preview with a versioned plugin ABI and Linux maps backend.
   It must remain default-off, and any promotion or kernel scope requires a
   separate decision backed by new evidence.

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -1,0 +1,430 @@
+# Options and status report for platform work
+
+> Scope: this is a **decision-and-status synthesis** of eight already-opened
+> draft pull requests (#2–#9) and their in-repository reviews, written for the
+> repository owners. It implements **no product feature**; it only records what
+> those branches landed, how their reviews judged them, what is now true versus
+> what the original documentation claimed, and which decisions still need a
+> human. It is docs-only and is **not a product ship**. Every draft branch was
+> read but left unchanged; this report is the only new file, added on a fresh
+> branch from `main`.
+>
+> Terminology is deliberately neutral: JNI-native transpiled JARs, bytecode
+> restoration, JVMTI diagnostics, process inspection, library instrumentation,
+> plugin ABI, privileged observer. No tool or product names.
+
+---
+
+## 中文摘要（先读这一节）
+
+本报告汇总 8 个已经打开的**草稿 PR（#2–#9）**及其仓库内评审结论，供仓库所有者
+决策。**本报告不实现任何产品功能**，只做"落地了什么 / 评审怎么判 / 现状与原始
+宣称的差距 / 还需人来拍板的决策 / 建议合并顺序"的梳理。所有功能分支只读不改，
+本报告是唯一新增文件，基于 `main` 新建分支提交，属于纯文档、**不是产品发布**。
+
+### (a) 以草稿 PR 形式落地了什么
+
+- **#2 设计理论评审 + PR 拆解序列**（纯文档）：判定"混淆器无关内核"只部分成立，
+  给出"通用优先 + 证据/状态契约"的方向和 0–10 的 PR 排序。可原样合并。
+- **#3 通用性审计**（纯文档）：逐条列出 85 处写死变体/编译器/操作系统/反编译器
+  形态的假设，只陈述事实、不改代码。可原样合并。
+- **#4 无需 Ghidra 的通用方法发现**（代码）：真正基于 JNI 结构（vtable 索引 215、
+  ABI 参数寄存器）发现方法表，ELF 路径有真实 fixture 在 CI 中验证；Ghidra 被降级
+  为可选的方法体插件。评审判定：**可作为草稿/开发分支合并，但不能作为默认发布**。
+- **#5 平台计划 + 决策记录 + 交叉核对**（纯文档）：第二份独立计划，区分"本计划可
+  自行决定"与"必须人来拍板"的决策（D1–D11 / B1–B11）。可原样合并。
+- **#6 doctor / setup 脚本 / 上手指南**（代码）：新增环境自检、安装脚本、双语上手
+  文档，把"手动 CLI"重新定位为默认用法。评审判定：**可作为草稿合并，但合并前必须
+  修复**（缺 `capstone` 依赖、JDK17→21 越级、doctor 误报就绪/把告警当阻断等 7 项）。
+- **#7 native-x86 隔离 + 插件 ABI**（文档 + 骨架）：独立的用户态观测骨架 + 版本化
+  C 插件 ABI，公共头**不含任何 Java/JNI 类型**，且**尚未实现任何观测**。评审判定：
+  **必须修复**（次版本协商会越界写内存、`process_id` 打错进程、生命周期/传输过度宣称）。
+- **#8 Swing 桌面查看器**（代码）：只读的 CLI 产物查看器（Swing + FlatLaf），不含任何
+  还原逻辑。视觉评审发现并修复 6 个问题，并删除了一个"附加—暂不可用"的假按钮。测试通过。
+- **#9 可选的 JVMTI 实时附加预览**（代码）：新增 `Agent_OnAttach` 与基于 `jdk.attach`
+  的**同用户**附加 CLI；默认 `recover` 流程不变。评审判定：**仅作为可选预览**，且已修复
+  三个必修项（jcmd 误报成功、能力宣称过高、`--log-all` 空开关）。
+
+**所有 8 个 PR 目前都是 OPEN + 草稿状态**，评审结论以仓库内文档形式存在（GitHub 上无
+正式 review 记录）。
+
+### (b) 现状 vs 原始仓库宣称
+
+- **通用优先**：原文档宣称"混淆器无关内核"。实际只有 JNI ABI 常量、`RegisterNatives`
+  语义、版本化 artifact、字节码发射器是真正通用的；#4 新增了真正通用的方法发现路径
+  （ELF 已验证），但它在草稿分支上、尚未成为默认，`main` 上仍有大量变体耦合（见 #3）。
+- **Ghidra 可选**：原文档把静态路径写成"需要 Ghidra"。#4/#6 在文档与命令层把 Ghidra
+  降级为可选方法体插件，并提供无 Ghidra 的发现/桩生成路径；但这尚未合并进 `main`。
+- **使用门槛**：原 README 主张"用编码 agent 驱动、别指望手动跑脚本"。#6 用 doctor + 安装
+  脚本 + 上手指南把手动 CLI 变成默认路径；但存在未修复的必修项，尚未合并。
+- **GUI**：原仓库只有静态截图，无桌面应用。#8 提供了只读桌面查看器（Swing + FlatLaf）。
+- **附加（attach）**：原实现里"attach"其实是用 `-agentpath` 启动新进程。#9 才提供真正的
+  实时附加预览（同用户 + 显式 `--pid`），但受 JVM 限制，实时附加通常只能拿到
+  native-method-bind 能力；完整方法体恢复仍需启动期 `-agentpath`。
+- **native-x86 隔离**：原仓库只有 `native/`（JVMTI agent）。#7 新增独立的 `native-x86/`
+  用户态模块，公共 ABI 不含 Java/JNI 类型，但目前是**骨架 + 文档**，未实现任何观测。
+
+### (c) 仍需人来拍板的决策（含推荐 + 是否已按推荐开工）
+
+| 决策 | 推荐 | 是否已按推荐开工 |
+|---|---|---|
+| "restored" 的含义 / 默认部分输出策略 | 定义为"通过校验 + 覆盖 + 行为检查"，另设 hybrid / inspection-only 标签；部分结果默认输出可运行的 hybrid JAR | **未**：`main` 仍是"剥离即默认"；默认翻转被显式推迟到人决策之后 |
+| 桌面技术栈 | Swing + FlatLaf | **已**：#8 已按此实现 |
+| 实时附加策略 | 同用户 + 显式 PID 确认；允许更严的企业策略 | **已**：#9 已按此实现为预览 |
+| native-x86 是否留在本仓库 | 留在仓库但保持隔离（可后续再拆分） | **部分**：骨架已在仓库内且已隔离；"留还是拆"仍开放 |
+| 插件信任 / 传输 | 版本化 C ABI，出现两个真实插件后再冻结；进程内先行，跨进程传输另行定义线格式 | **部分**：#7 给出 ABI 设计与骨架，但有内存安全必修项，传输尚未定义 |
+| 是否要做特权观测者 | **默认否**，仅在测得用户态确有反复无法覆盖的盲区后，作为后期可选项 | **未**（符合推荐）：仅有边界文档，无任何代码 |
+| 敏感缓冲区 / 库观测 | **默认只采集元数据**；如需内容，须单会话、本地、可打码、显式开启、不外传 | **未**（符合推荐）：未实现；native-x86 记录仅为结构性元数据 |
+
+### (d) 建议合并顺序
+
+先文档（#2、#3、#5、以及本报告）→ 再 doctor/setup（#6，修完必修项后）→
+通用发现（#4，作为草稿/开发合并，未达默认发布）→ 桌面查看器（#8）→
+实时附加（#9，保持可选预览）→ native-x86（#7，修完必修项后仅作开发者预览）。
+
+**在各自评审说 OK 之前不得合并/提升**：#4 在未关闭"仅按数量的无名表定位误绑"前不得
+成为默认发布路径；#6 未修完 7 项必修项不得合并；#7 未修好次版本协商越界写与
+`process_id` 打错前不得被当作稳定 ABI；#9 必须保持可选预览、不得提升为默认或宣称完整
+覆盖；未获人决策前不得开工敏感缓冲区/库内容采集与特权观测者。
+
+### 明确不在范围内 / 未做
+
+真实用户态加密库插桩（内容采集）、内核驱动 / 特权观测者实现、任何 Web / 浏览器界面。
+以上都只有边界或"未来插件"文档，没有任何实现，也不应在缺少对应人决策前实现。
+
+---
+
+## How to read this report
+
+- **"Ship as-is?"** means the branch can be merged and released **for its stated
+  scope** without waiting on a later branch. It never means "skip review."
+- **"Review status"** summarizes the verdict recorded in each branch's own review
+  document (`docs/reviews/*.md`, or the review sections inside the docs branches).
+  On GitHub all eight are `OPEN` drafts with no formal review decision recorded;
+  the substantive review lives in-repo.
+- Base for all diffs is `main` at `3843ec1`.
+
+---
+
+## 1. What landed as draft pull requests
+
+| PR | Branch | Scope | Ship as-is? | Review status |
+|---:|---|---|---|---|
+| **#2** | `cursor/design-theory-review-465c` | Docs only: skeptical design-theory review of `main`, recovery-path scorecard, generic-first direction, desktop pick, observer boundaries, human/no-human decision split, and a 0–10 PR-sequence (`docs/design-theory-review.md`, `docs/pr-sequence.md`). No runtime change. | **Yes — docs-only.** | Self-described authorized second-opinion review; changes no behavior. Mergeable as documentation; owner/design sign-off is the only gate. |
+| **#3** | `cursor/genericity-audit-966b` | Docs only: inventory of **85 findings** where code assumes a specific variant, compiler, OS/CPU, or decompiler output shape (`docs/genericity-audit.md`). Facts only, no fix. | **Yes — docs-only.** | Factual inventory; nothing is "fixed" by it. Mergeable as a reference for later generality work. |
+| **#4** | `cursor/generic-first-discovery-ca12` | Code: generic method discovery from JNI structure (vtable index 215 via decoded operands, ABI arg registers, `Java_*` exports), Ghidra demoted to an optional method-body plugin, new `static-lite`/`inventory`-style commands, schema additions, tests + a real ELF fixture (`docs/reviews/generic-first-pr.md`, `docs/generic-recovery.md`). | **As a draft / dev merge: yes. As the default release: no.** | Reviewed twice. Both original must-fixes resolved (real-ELF loading test committed; lifter derives profile from the artifact). Full Python suite 21 passed. Residual (not must-fix): unnamed count-only positional mis-binding; PE/Mach-O loading unproven; section-stripped ELF returns a silent empty registry. |
+| **#5** | `cursor/platform-plan-docs-7274` | Docs only: a second, independent platform plan plus ADR-style decision records that split "decisions this plan makes" (D1–D11) from "decisions reserved for a human" (B1–B11), and a cross-check against #2 (`docs/platform-plan.md`, `docs/decisions.md`, `docs/plan-crosscheck.md`). | **Yes — docs-only.** | Endorses #2's diagnosis; differs on sequencing (front-load decision-free value; defer the event-IR/fusion rebuild). Mergeable as documentation. |
+| **#6** | `cursor/cli-doctor-setup-getting-started-b8b1` | Code: read-only `doctor` preflight, `setup.sh`/`setup.ps1`, `j2c` launchers, bilingual getting-started, Ghidra-free tests; both READMEs reframed so manual CLI is the default and assisted adaptation is optional (`docs/reviews/cli-doctor-setup.md`). | **Ship as draft; must-fix before merge.** | Directionally right, but 7 must-fix items: missing `capstone` dependency (doctor can print `Ready` before `recover` fails), unneeded repo-wide JDK 17→21 bump, native-artifact checks that neither prove readiness nor rebuild staleness, warnings treated as blocking, no-argument path exits non-zero, an undocumented Windows `bash` prerequisite, and readiness/output claims that overstate what `doctor` checks. May still be in re-review. |
+| **#7** | `cursor/native-x86-plugin-abi-5384` | Docs + skeleton: a separate user-mode `native-x86/` module (owned-process/module enumeration, PE/ELF inspection, scoped instrumentation — **none implemented yet**), a versioned C plugin ABI whose public header carries **no Java/JNI types**, and a boundary doc for an optional, unimplemented privileged observer (`docs/reviews/native-x86-abi.md`, `docs/plugin-abi.md`, `docs/privileged-observer.md`). | **No — developer preview / design only.** | Must-fix: minor-version negotiation can overwrite host memory; `process_id` is stamped with the host PID instead of the observed process (or zero); lifecycle/transport docs claim guarantees the skeleton does not enforce. Java/JNI isolation, recovery-pipeline isolation, and the Linux smoke build all pass. |
+| **#8** | `cursor/swing-desktop-viewer-7389` | Code: an optional read-only Swing + FlatLaf desktop viewer that launches CLI stages and renders pipeline status, the method table, and JVMTI trace — **no recovery logic, no browser server** (`docs/reviews/desktop-ui-visual.md`, `jvm/desktop-ui/README.md`). | **Yes, optional** — after CLI/event contracts are stable. | Visual review found and fixed 6 issues (clipped detail pane, mid-token command wrap, centered headers, jumping divider, non-reproducible screenshots) and **removed a permanently-disabled "Attach — not available yet" button**. `:desktop-ui:test` passes. Note: the module targets JDK 21 while the rest of `jvm/` targets JDK 17. |
+| **#9** | `cursor/opt-in-jvmti-live-attach-1155` | Code: opt-in live attach preview — export `Agent_OnAttach`, a `jdk.attach` **same-user** CLI (`--i-own-this-process` + required explicit `--pid`), lazy per-thread install, capability/gap/drop records over the existing agent; default `recover` (startup `-agentpath`) unchanged (`docs/reviews/jvm-attach.md`, `docs/jvm-attach.md`). | **No initially — opt-in preview only.** | Three must-fix items resolved: `jcmd` false success on load failure, coverage claims that exceeded what a live attach obtains, and a dead `--log-all` switch. Empirically on OpenJDK 21 a live attach obtains **only** `native-method-bind`; entry/exit/locals/exception are `OnLoad`-only, so records and docs were corrected to say so. Full method-body recovery still needs the startup path. |
+
+---
+
+## 2. What is true now versus what the original repo claimed
+
+Each row states the **original claim** (from `main`'s README/architecture docs),
+what the draft PRs make **true now** (on their branches, not yet on `main`), and
+the **gap** an owner should keep in mind.
+
+### 2.1 Generic-first
+
+- **Original claim.** The core is "obfuscator-agnostic," with variant knowledge
+  confined to profiles and architecture modules, and the core "never branches on
+  a named producer."
+- **True now.** Only the standards-derived kernel is genuinely generic: JNI ABI
+  constants, `RegisterNatives` semantics, versioned JSON artifacts, and the ASM
+  emitter. #3 documents 85 places where producer/compiler/OS/decompiler shape is
+  assumed outside `Profile`. #4 adds a genuinely generic discovery path
+  (structural `RegisterNatives` detection + ABI arg registers + `Java_*` exports)
+  and proves the ELF loading path in CI.
+- **Gap.** #4 is a draft, not the default and not merged. On `main` the static
+  lifter, cache-table scanner, string-pool scoring, loader detection, and rebuild
+  cleanup remain variant/OS-coupled. The correct summary is "standards-derived
+  primitives plus some extension points," not "agnostic end to end."
+
+### 2.2 Ghidra optional
+
+- **Original claim.** The static path "requires Ghidra"; static coverage tables
+  read as near-complete.
+- **True now.** #4 demotes Ghidra to an optional method-body plugin in help text,
+  stub notes, the `static-reverse` command, both READMEs, and
+  `docs/generic-recovery.md`; discovery, manifest, and restoration stubs are
+  produced with no decompiler. #6 labels Ghidra "Advanced / optional" and its new
+  tests run without it. #5/#2 mark the stale static-approach doc for correction.
+- **Gap.** Not yet on `main`. The one remaining "requires Ghidra" string (in
+  `docs/ROADMAP.md`) accurately describes a CI limitation of the static-path
+  end-to-end tests, not a hard tool requirement.
+
+### 2.3 Usage barrier
+
+- **Original claim.** "The best way to use this project is to drive it with a
+  coding agent… don't expect to just run the ready-made scripts by hand."
+- **True now.** #6 adds a read-only `doctor` preflight, `setup.sh`/`setup.ps1`,
+  `j2c` launchers, and a bilingual getting-started guide, and reframes both
+  READMEs so **manual CLI use is the default** and assisted adaptation is
+  optional.
+- **Gap.** Not merged, and its own review lists 7 must-fix items — most notably
+  that `doctor` can approve an unusable install (missing `capstone`) and reject a
+  usable one (warnings treated as blocking). The barrier is lowered on the branch
+  but not yet reliably.
+
+### 2.4 GUI
+
+- **Original claim.** None — the repo shipped only auto-generated static
+  screenshots.
+- **True now.** #8 adds an optional read-only desktop viewer (Swing + FlatLaf)
+  that is strictly a client of the CLI: it launches stages and renders their JSON
+  (pipeline status, method table, trace) and contains no recovery logic and no
+  browser server.
+- **Gap.** It waits on stable CLI/event contracts, and the module targets JDK 21
+  while the rest of `jvm/` targets JDK 17 (a toolchain split to resolve).
+
+### 2.5 Attach
+
+- **Original claim.** The CLI's "attach" wording actually meant launching a new
+  process with `-agentpath`; the agent had `Agent_OnLoad`/`Agent_OnUnload` but no
+  `Agent_OnAttach`, and initialized on `VMInit` (already past in a running JVM).
+- **True now.** #9 adds a real live-attach **preview**: `Agent_OnAttach`, a
+  `jdk.attach` same-user CLI gated by `--i-own-this-process` and a required
+  explicit `--pid`, lazy per-thread install, and honest capability/gap/drop
+  records. The default `recover` path is unchanged.
+- **Gap.** Live attach is JVM-limited: on OpenJDK 21 it obtains only
+  native-method-bind; entry/exit/locals/exception are `OnLoad`-only. Full
+  method-body recovery still requires the startup `-agentpath` path. Threads
+  already running at attach time never get per-JNI-call argument capture (reported
+  as a gap record).
+
+### 2.6 Native-x86 isolation
+
+- **Original claim.** The only native component was `native/` — the in-process
+  JVMTI agent.
+- **True now.** #7 adds a separate `native-x86/` user-mode module with a versioned
+  C plugin ABI whose public header carries **no Java/JNI types** (verified), and
+  keeps the recovery pipeline (`py/`, `jvm/`, `native/`, `ghidra/`) untouched. A
+  future JVM adapter is documented as living *outside* this directory.
+- **Gap.** It is a **skeleton plus documentation** — no process observation or
+  instrumentation is implemented — and it has memory-safety and labeling must-fix
+  items (see §3.5). Some design docs overclaim ABI stability, lifecycle gating,
+  and out-of-process transport relative to what the skeleton enforces.
+
+---
+
+## 3. Human decisions still open
+
+For each: the concrete options, the recommendation carried by the reviews, the
+consequences, and **whether work already proceeded** on the recommended option.
+These are the decisions the reviews explicitly reserve for a human because they
+commit the project to user expectations, security policy, toolchains, or
+long-term maintenance.
+
+### 3.1 Meaning of "restored" and the default partial-output policy
+
+- **Options — "restored".** (A) decompilable; (B) verifier-clean; (C)
+  verifier-clean **plus** method coverage and behavior checks.
+- **Options — partial output.** (A) strip native resources anyway; (B) emit a
+  hybrid runnable JAR by default; (C) evidence-only.
+- **Recommendation.** "Restored" = (C), with separate **`hybrid`** and
+  **`inspection-only`** labels. Partial output = (B) by default; (C) only when
+  safe retention is impossible. A verifier-clean body full of synthetic defaults
+  is still **partial**, and a "clean JAR" that is non-loadable must never be
+  called restored.
+- **Consequences.** A higher, clearer bar per "restored" claim and partial
+  results that stay runnable, at the cost of a slightly more complex default
+  artifact and a migration of today's "clean JAR" wording.
+- **Work already proceeded?** **No — and this is the most important open gap.**
+  Today's rebuilder can strip the loader/native blob while methods remain stubbed,
+  and artifacts do not yet carry source/confidence. The reviews recommend adding
+  additive `source`/`confidence`/`capability` fields and an *opt-in* hybrid mode
+  first, and deferring the **default** policy flip until this decision is made. No
+  branch in this set flips the default; #4's review flags the strip-while-stubbed
+  behavior as a should-fix.
+
+### 3.2 Desktop stack
+
+- **Options.** Swing + FlatLaf; JavaFX; Compose Desktop.
+- **Recommendation.** **Swing + FlatLaf** — it reuses the existing JVM/Gradle
+  build, `java.desktop` ships with the JDK, the workload is tables/trees/log
+  streams, and packaging (`jlink`/`jpackage`) can wait until the module is stable.
+  A browser interface is explicitly out of scope.
+- **Consequences.** Small, JDK-native footprint; an imperative UI style that needs
+  disciplined event-dispatch-thread handling.
+- **Work already proceeded?** **Yes — confirm.** #8 already built the viewer on
+  Swing + FlatLaf as a read-only CLI client, with the visual review's fixes
+  applied and tests passing. The open sub-item is the JDK 17/21 toolchain split,
+  not the toolkit choice. Recommendation: **confirm Swing + FlatLaf** and scope
+  JDK 21 to the desktop module only.
+
+### 3.3 Live attach policy
+
+- **Options.** Any accessible PID; same-user + explicit PID confirmation; explicit
+  allowlist.
+- **Recommendation.** **Same-user + explicit PID confirmation**, while allowing a
+  stricter enterprise policy. Never conceal the agent, never patch attach checks;
+  offer documented modes (startup `-agentpath`, offline emulation, user-mode
+  observation) when a target disables or detects attach.
+- **Consequences.** A safe default; power users on shared hosts need extra
+  configuration. Process access is a security/product policy, not an
+  implementation detail.
+- **Work already proceeded?** **Yes — as a preview.** #9 implements same-user +
+  `--i-own-this-process` + required explicit `--pid`, retains the same-user /
+  looks-like-Java validation, and adds no stealth/evasion/kernel/TLS behavior. The
+  open decision is whether to keep it same-user by default (recommended) and
+  whether to add an enterprise allowlist; the implementation must remain an
+  **opt-in preview** until the JVM/concurrency/privacy/security review clears it.
+
+### 3.4 Whether native-x86 stays in this repository
+
+- **Options.** Keep it in this repository (isolated); split it into a separate
+  project.
+- **Recommendation.** **Keep it in-repo but strictly isolated** for now: no
+  dependency from the recovery pipeline into `native-x86/`, no Java/JNI types in
+  its public ABI, and any JVM adapter placed outside the directory. Revisit a
+  split only if the module grows its own release cadence.
+- **Consequences.** Keeping it in-repo keeps one review surface and shared CI;
+  splitting later is cheap **because** the isolation rules are enforced now.
+  Letting the boundary blur would make a later split expensive.
+- **Work already proceeded?** **Partially.** The skeleton already lives in-repo
+  and is isolated (recovery pipeline untouched; Java/JNI isolation verified). The
+  keep-vs-split call itself remains open and is listed as a human decision in #7's
+  review.
+
+### 3.5 Plugin trust and transport
+
+- **Options — ABI stability.** Unstable C++; **versioned C ABI**; a
+  language-specific in-process API.
+- **Options — trust.** Trust plugins in-process; require out-of-process isolation.
+- **Options — transport.** In-process only; a defined out-of-process wire schema.
+- **Recommendation.** A **versioned C ABI** (opaque handles, explicit `size` /
+  `abi_version` fields, host-owned allocators, bounded/redaction-aware events),
+  **frozen only after two real plugins exist**. Treat the in-process path as the
+  starting point and **define a real wire schema before claiming out-of-process
+  transport**. Decide trust explicitly rather than defaulting to in-process trust.
+- **Consequences.** A stable, long-lived extension point, but ABI compatibility
+  becomes a maintenance obligation, so the freeze is deliberately evidence-gated.
+- **Work already proceeded?** **Partially, and it is not yet safe to rely on.** #7
+  publishes the C ABI design and a working skeleton, but the review found the
+  minor-version negotiation can **overwrite host memory** (both sides currently
+  reject `struct_size` mismatches instead of reading only the common prefix), the
+  event copy is shallow with process-local pointers (so "drop-in" out-of-process
+  transport is overclaimed), and the lifecycle "events only between start/stop" is
+  not enforced. These must be fixed before the ABI is treated as a versioned
+  extension mechanism. The trust model is explicitly left to a human.
+
+### 3.6 Whether a privileged observer should ever be built
+
+- **Options.** Make it a foundation; do early parallel work; treat it as a later,
+  optional, gated component.
+- **Recommendation.** **Default: no.** Only a **later optional gate**, and only
+  after user-mode telemetry demonstrates a concrete, repeated visibility gap that
+  user-mode observation provably cannot serve, with maintainer-approved threat and
+  support models. The user would enable OS debug/test-signing themselves; **the
+  project ships no signed driver**, automates no security-weakening step, and adds
+  no stealth, no signature/integrity bypass, no hidden loaders, no interception,
+  and no data exfiltration. It would emit the *same* neutral records as the
+  user-mode path behind the *same* plugin ABI.
+- **Consequences.** Keeps system-wide crash/blast-radius, per-kernel maintenance,
+  and un-CI-able configurations out of the default path. The cost is high,
+  permanent, and paid by maintainers; the benefit is narrow.
+- **Work already proceeded?** **No, by design.** Only a boundary document exists
+  (`docs/privileged-observer.md`): no kernel source, driver project, build target,
+  or binary. Nothing in the default workflow, method inventory, GUI, or plugin ABI
+  depends on it. This matches the recommendation; keep it doc-only until the bar
+  is met.
+
+### 3.7 Sensitive buffer / library observation
+
+- **Options.** Always capture buffer/key contents; **metadata-only**; explicit
+  content opt-in.
+- **Recommendation.** **Metadata-only by default** (function identity, sizes,
+  algorithm identifiers, return status, call correlation). Any content capture
+  must be a separate, per-session, **local-only**, redaction-aware, explicitly
+  indicated option with a retention policy and **no remote upload**. Well-known
+  cryptographic entry points may be *named* as points of interest; hooking them is
+  a later opt-in plugin, not a default.
+- **Consequences.** A safe default posture; full-content diagnostics require a
+  deliberate switch and a redaction/retention policy, because buffers can contain
+  credentials and personal data.
+- **Work already proceeded?** **No — not implemented (correctly).** The
+  `native-x86/` records are structural metadata only; there is no buffer or key
+  capture, and the crypto-library plugins + JVM bridge are a later, gated,
+  still-unbuilt step. If content observation is ever built, it must be metadata-only
+  by default with content strictly opt-in as above.
+
+### 3.8 Other reserved decisions (for completeness)
+
+These also require a human but were not called out individually in the task.
+
+| Decision | Options | Recommendation | Work proceeded? |
+|---|---|---|---|
+| Event-IR + evidence-fusion: now or later | build now as the new core; defer behind additive provenance fields | **Defer**; formalize a shared event schema only after two real producers (emulation + live attach) need it | No — additive fields recommended first; the fusion subsystem is deliberately deferred |
+| First supported platform set | Windows x64 only; **Windows + Linux x64**; all formats/arches | Windows + Linux x64 user mode first (matches current two x86-64 ABI modules) | Matches current coverage; AArch64/macOS deferred |
+| Cross-language producer knowledge | port the Python `Profile` into the JVM modules; a shared producer-hints JSON; leave duplicated | **Shared producer-hints JSON** consumed by both the Python profile layer and the two Kotlin modules | No — proposed only |
+| Dependency distribution | bundle everything; download at runtime; **bundle GUI/runtime, user supplies Ghidra** | Bundle GUI/runtime; user supplies optional Ghidra | No — proposed only |
+
+---
+
+## 4. Suggested merge order for the draft PRs
+
+The order deliberately establishes **truthful docs and lowered setup friction
+before** adding more front ends or observers. Docs branches are mergeable now
+(owner sign-off aside); code branches merge only after their review gates clear.
+
+1. **Docs first — #2, #3, #5 (+ this report).** Docs-only; they change no runtime
+   behavior and set the contracts and honest labels everything else references.
+   Merge in any order among themselves.
+2. **#6 — doctor / setup / getting-started.** After its **7 must-fix items** are
+   resolved. It removes the largest usage barrier and is a prerequisite for a
+   good first-run experience.
+3. **#4 — generic-first discovery.** As a **draft / development merge**, not as
+   the default release path. It proves the generic front door (ELF verified).
+4. **#8 — Swing desktop viewer.** After the CLI/event contracts it consumes are
+   stable; visual fixes are already applied.
+5. **#9 — live attach.** Kept an **opt-in preview**; the default `recover` path
+   stays on startup `-agentpath`.
+6. **#7 — native-x86 core + plugin ABI.** After its **must-fix items** are fixed,
+   and only as a **developer preview**.
+
+### What must not be merged / promoted until its review says so
+
+- **#4 must not become the default release path** until the unnamed **count-only
+  positional mis-binding** is closed (it silently binds a stack table to the first
+  class with a matching native-method count); PE (`.dll`) and Mach-O loading paths
+  should also be proven by committed fixtures.
+- **#6 must not merge** until the missing `capstone` dependency, the unnecessary
+  repo-wide JDK 17→21 bump, the native-artifact readiness/idempotence checks, the
+  warnings-as-blocking bug, the non-zero no-argument exit, the undocumented Windows
+  `bash` prerequisite, and the overstated readiness/output claims are addressed.
+- **#7 must not be treated as a stable ABI or shipped beyond a developer preview**
+  until the minor-version negotiation memory-overwrite and the `process_id`
+  mislabeling are fixed and the lifecycle/transport docs are narrowed to what is
+  enforced.
+- **#9 must stay an opt-in preview**; it must not be promoted to the default
+  `recover` path and must not claim entry/exit/locals/exception coverage unless the
+  per-capability record reports it available.
+- **No branch may label output "restored" from an inspection-only or verifier-only
+  artifact**, and the default output policy must not be flipped, until the meaning
+  of "restored" and the partial-output policy (§3.1) are decided.
+- **Sensitive buffer/library-content capture and any privileged observer must not
+  be built** until their human decisions (§3.6, §3.7) are made.
+
+---
+
+## 5. Explicitly out of scope / not done
+
+The following are **not implemented anywhere** in these branches, exist only as
+boundary or "future plugin" documentation, and must not be built before their
+corresponding human decisions are made:
+
+- **Real user-mode cryptographic-library instrumentation with content capture.**
+  Well-known entry points may be *named* as points of interest; the crypto-library
+  plugins and the JVM bridge are a later, gated, unbuilt step. Default remains
+  metadata-only.
+- **Kernel driver / privileged observer implementation.** Documentation-only
+  boundary (`docs/privileged-observer.md`): no kernel source, driver project,
+  build target, or binary. Default is user mode; the project ships no signed
+  driver.
+- **Any Web / browser interface.** Explicitly vetoed. The only UI is the optional
+  read-only desktop viewer (#8); the CLI remains the sole automation contract.
+
+This report itself implements no product feature and is docs-only.

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -1,439 +1,172 @@
-# Options and status report for platform work
+# Options and status report for JNI-native recovery platform work
 
-> Scope: this is a **decision-and-status synthesis** of eight already-opened
-> draft pull requests (#2–#9) and their in-repository reviews, written for the
-> repository owners. It implements **no product feature**; it only records what
-> those branches landed, how their reviews judged them, what is now true versus
-> what the original documentation claimed, and which decisions still need a
-> human. It is docs-only and is **not a product ship**. Every draft branch was
-> read but left unchanged; this report (PR #10) is the only new file, added on a
-> fresh branch from `main`.
+> Status checked against GitHub on 2026-08-28. Pull requests #2 through #12 are
+> all open, unmerged drafts. This report is documentation only; it does not
+> implement or promote a product feature.
 >
-> Terminology is deliberately neutral: JNI-native transpiled JARs, bytecode
-> restoration, JVMTI diagnostics, process inspection, library instrumentation,
-> plugin ABI, privileged observer. No tool or product names.
+> Terminology in this report is deliberately neutral: JNI-native transpiled JAR
+> recovery, JVMTI, process inspection, library instrumentation, plugin ABI, and
+> privileged observer.
 
----
+## Executive recommendation
 
-## 中文摘要（先读这一节）
+Keep the command-line recovery path as the automation contract. Merge truthful
+documentation and setup work first, then add the generic discovery path only as
+a development draft. Layer the optional desktop work and JVMTI attach preview
+after their dependencies. Treat native-x86 as a preview draft rather than a
+product feature, and merge the privileged-observer documentation mock last.
 
-本报告汇总 8 个已经打开的**草稿 PR（#2–#9）**及其仓库内评审结论，供仓库所有者
-决策。**本报告不实现任何产品功能**，只做"落地了什么 / 评审怎么判 / 现状与原始
-宣称的差距 / 还需人来拍板的决策 / 建议合并顺序"的梳理。所有功能分支只读不改，
-本报告是唯一新增文件，基于 `main` 新建分支提交，属于纯文档、**不是产品发布**。
+Nothing in the current drafts justifies making generic discovery, live attach,
+native-x86, or privileged observation a default release path.
 
-### (a) 以草稿 PR 形式落地了什么
+## Pull request status and shipping verdicts
 
-- **#2 设计理论评审 + PR 拆解序列**（纯文档）：判定"混淆器无关内核"只部分成立，
-  给出"通用优先 + 证据/状态契约"的方向和 0–10 的 PR 排序。可原样合并。
-- **#3 通用性审计**（纯文档）：逐条列出 85 处写死变体/编译器/操作系统/反编译器
-  形态的假设，只陈述事实、不改代码。可原样合并。
-- **#4 无需 Ghidra 的通用方法发现**（代码）：真正基于 JNI 结构（vtable 索引 215、
-  ABI 参数寄存器）发现方法表，ELF 路径有真实 fixture 在 CI 中验证；Ghidra 被降级
-  为可选的方法体插件。评审判定：**可作为草稿/开发分支合并，但不能作为默认发布**。
-- **#5 平台计划 + 决策记录 + 交叉核对**（纯文档）：第二份独立计划，区分"本计划可
-  自行决定"与"必须人来拍板"的决策（D1–D11 / B1–B11）。可原样合并。
-- **#6 doctor / setup 脚本 / 上手指南**（代码）：新增环境自检、安装脚本、双语上手
-  文档，把"手动 CLI"重新定位为默认用法。评审判定：原 7 项必修项已解决，**现处于最后
-  收尾细节阶段**（README 仍残留 `python -m` 示例、ARM 上 doctor 不得把 ARM 标记的
-  遗留 agent 判为 OK、README 引言仍过度宣称"真实字节码方法体"）。
-- **#7 native-x86 隔离 + 插件 ABI**（文档 + 骨架）：独立的用户态观测骨架 + 版本化
-  C 插件 ABI，公共头**不含任何 Java/JNI 类型**，且**尚未实现任何观测**。评审判定：
-  经必修 + 复审后，**作为文档 + 实验性骨架落地**；早前的 `process_id` / 次版本协商越界写
-  问题已修复；**ABI v0.1 明确为实验性、非产品功能**。
-- **#8 Swing 桌面查看器**（代码）：只读的 CLI 产物查看器（Swing + FlatLaf），不含任何
-  还原逻辑。视觉评审已完成、发现并修复 6 个问题并删除了一个"附加—暂不可用"的假按钮；
-  测试通过。属于**可选桌面草稿**，与其余模块存在 JDK 17/21 分歧，**非正式 UI 发布**。
-- **#9 可选的 JVMTI 实时附加预览**（代码）：新增 `Agent_OnAttach` 与基于 `jdk.attach`
-  的**同用户**附加 CLI；默认 `recover` 流程不变。评审判定：经必修 + 复审后，**作为预览
-  草稿落地**；三个必修项（jcmd 误报成功、能力宣称过高、`--log-all` 空开关）已修复；
-  OpenJDK 21 实时附加常常只能拿到 bind 能力，**不作默认 recover**。
+“Can ship” below means only within the stated draft or documentation scope. It
+does not mean that a draft is merged, that a preview is a default, or that owner
+review can be skipped.
 
-**所有 8 个 PR 目前都是 OPEN + 草稿状态**，评审结论以仓库内文档形式存在（GitHub 上无
-正式 review 记录）。
+| PR | Scope and current verdict | Can ship? | Is review still needed? |
+|---:|---|---|---|
+| **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
+| **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
+| **#4** | Generic-first discovery. The count-only silent misbind is closed. PE, Mach-O, and stripped-ELF behavior remain unproven. | **Yes, as a draft/development path; not as the default release.** | Yes, before any default promotion and when adding evidence for the unproven formats. |
+| **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
+| **#6** | `doctor`, setup scripts, launchers, and getting-started material. JDK 17 is retained. | **Yes, as a draft.** | Normal merge review remains; no JDK migration is implied. |
+| **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `8b9231c145e80acbc723fbc893d072398cba143b`, after multiple must-fix rounds. | **Yes, as a preview draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. The current preview verdict is supported by the completed review rounds and smoke evidence. |
+| **#8** | Optional Swing + FlatLaf artifact viewer. The visual pass is complete. The desktop module uses JDK 21 while the repository baseline remains JDK 17. | **Yes, as an optional desktop draft.** | Yes, principally for the JDK 21 module boundary and normal merge review. |
+| **#9** | Opt-in JVMTI attach. OpenJDK 21 live attach is often bind-only; default recovery remains startup `-agentpath`. | **Yes, as a preview draft only.** | Yes before any capability or default-policy expansion. |
+| **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
+| **#11** | Optional privileged-observer contract. It is a documentation mock with Linux userspace maps mock behavior only and no kernel source. | **Yes, as a docs mock only.** | Yes before any implementation work; the default remains no privileged observer. |
+| **#12** | Desktop live-attach/listen GUI, based on PR #8’s branch rather than `main`. Visual review is preview-ok. | **Yes, as a preview after #8.** | Yes for integration review after #8 and for the same attach limitations as #9. |
 
-### (b) 现状 vs 原始仓库宣称
+## Current evidence and boundaries
 
-- **通用优先**：原文档宣称"混淆器无关内核"。实际只有 JNI ABI 常量、`RegisterNatives`
-  语义、版本化 artifact、字节码发射器是真正通用的；#4 新增了真正通用的方法发现路径
-  （ELF 已验证），但它在草稿分支上、尚未成为默认，`main` 上仍有大量变体耦合（见 #3）。
-- **Ghidra 可选**：原文档把静态路径写成"需要 Ghidra"。#4/#6 在文档与命令层把 Ghidra
-  降级为可选方法体插件，并提供无 Ghidra 的发现/桩生成路径；但这尚未合并进 `main`。
-- **使用门槛**：原 README 主张"用编码 agent 驱动、别指望手动跑脚本"。#6 用 doctor + 安装
-  脚本 + 上手指南把手动 CLI 变成默认路径；原 7 项必修项已解决，仅剩最后收尾细节，尚未合并。
-- **GUI**：原仓库只有静态截图，无桌面应用。#8 提供了只读桌面查看器（Swing + FlatLaf）。
-- **附加（attach）**：原实现里"attach"其实是用 `-agentpath` 启动新进程。#9 才提供真正的
-  实时附加预览（同用户 + 显式 `--pid`），但受 JVM 限制，实时附加通常只能拿到
-  native-method-bind 能力；完整方法体恢复仍需启动期 `-agentpath`。
-- **native-x86 隔离**：原仓库只有 `native/`（JVMTI agent）。#7 新增独立的 `native-x86/`
-  用户态模块，公共 ABI 不含 Java/JNI 类型，但目前是**骨架 + 文档**，未实现任何观测。
+### Generic-first discovery (#4)
 
-### (c) 仍需人来拍板的决策（含推荐 + 是否已按推荐开工）
+- The earlier count-only silent misbind is closed.
+- The branch can be used as a draft/development path.
+- It is not the default release path.
+- PE and Mach-O loading are not yet proven by committed evidence.
+- Stripped-ELF behavior is not yet proven.
 
-| 决策 | 推荐 | 是否已按推荐开工 |
-|---|---|---|
-| "restored" 的含义 / 默认部分输出策略 | 定义为"通过校验 + 覆盖 + 行为检查"，另设 hybrid / inspection-only 标签；部分结果默认输出可运行的 hybrid JAR | **未**：`main` 仍是"剥离即默认"；默认翻转被显式推迟到人决策之后 |
-| 桌面技术栈 | Swing + FlatLaf | **已**：#8 已按此实现 |
-| 实时附加策略 | 同用户 + 显式 PID 确认；允许更严的企业策略 | **已**：#9 已按此实现为预览 |
-| native-x86 是否留在本仓库 | 留在仓库但保持隔离（可后续再拆分） | **部分**：骨架已在仓库内且已隔离；"留还是拆"仍开放 |
-| 插件信任 / 传输 | 版本化 C ABI，出现两个真实插件后再冻结；进程内先行，跨进程传输另行定义线格式 | **部分**：#7 给出 ABI 设计与骨架，早前内存安全必修项经复审已修复；ABI v0.1 仍为实验性、未冻结，跨进程线格式与信任模型仍待定 |
-| 是否要做特权观测者 | **默认否**，仅在测得用户态确有反复无法覆盖的盲区后，作为后期可选项 | **未**（符合推荐）：仅有边界文档，无任何代码 |
-| 敏感缓冲区 / 库观测 | **默认只采集元数据**；如需内容，须单会话、本地、可打码、显式开启、不外传 | **未**（符合推荐）：未实现；native-x86 记录仅为结构性元数据 |
+The consequence is deliberate: developers can continue validating the generic
+path without presenting incomplete platform coverage as a released default.
 
-### (d) 建议合并顺序
+### Setup and launchers (#6)
 
-先文档（#2、#3、#5、以及本报告 #10）→ 再 doctor/setup（#6，收尾细节完成后）→
-通用发现（#4，作为草稿/开发合并，未达默认发布）→ 桌面查看器（#8，可选草稿）→
-实时附加（#9，保持预览）→ native-x86（#7，作为实验性文档骨架）。
+- The branch can ship as a draft.
+- The repository baseline remains JDK 17.
+- Desktop-specific JDK 21 requirements do not move this setup path to JDK 21.
 
-**在各自评审说 OK 之前不得合并/提升**：#4 在未关闭"仅按数量的无名表定位误绑"前不得
-成为默认发布路径；#6 未完成最后收尾细节不得合并；#7 的 ABI v0.1 为实验性，未经稳定化
-不得被当作稳定 ABI 或产品功能；#9 必须保持可选预览、不得提升为默认或宣称完整覆盖；
-未获人决策前不得开工敏感缓冲区/库内容采集与特权观测者。
+This keeps the baseline stable while allowing the optional desktop module to
+carry an explicit module-local toolchain requirement.
 
-### 明确不在范围内 / 未做
+### Native-x86 preview (#7)
 
-真实用户态加密库插桩（内容采集）、内核驱动 / 特权观测者实现、任何 Web / 浏览器界面。
-以上都只有边界或"未来插件"文档，没有任何实现，也不应在缺少对应人决策前实现。
+The reviewed preview revision is
+`8b9231c145e80acbc723fbc893d072398cba143b`.
 
----
+- `bash native-x86/smoke-test.sh` passes sections 1–14.
+- Observation is metadata-only.
+- Live register metadata is limited to RIP and RSP.
+- Command-line integer parsing is strict.
+- A live-operation error fails the operation and restores the target state.
+- Multi-threaded targets refuse live operation and fall back to read-only
+  inspection.
+- Windows live operation is not shipped.
+- No kernel component is shipped.
+- `note.text` is constrained by policy and a 512-byte cap. This is a policy and
+  bounded-record decision, not a claim of structural impossibility.
 
-## How to read this report
+PR #7 and PR #11 overlap on `docs/privileged-observer.md`. PR #7 stopped editing
+that file, but the branch histories still make this a merge-order concern.
+Merge #7 after the main documentation set and merge #11 last.
 
-- **"Ship as-is?"** means the branch can be merged and released **for its stated
-  scope** without waiting on a later branch. It never means "skip review."
-- **"Review status"** summarizes the verdict recorded in each branch's own review
-  document (`docs/reviews/*.md`, or the review sections inside the docs branches).
-  On GitHub all eight are `OPEN` drafts with no formal review decision recorded;
-  the substantive review lives in-repo.
-- Base for all diffs is `main` at `3843ec1`.
+These facts support **ship-as-preview-draft**, not a stable ABI claim or product
+feature claim.
 
----
+### Optional desktop work (#8 and #12)
 
-## 1. What landed as draft pull requests
+- PR #8’s visual pass is complete.
+- PR #8 is an optional artifact viewer and does not replace the CLI.
+- Its module requires JDK 21 while the repository baseline remains JDK 17.
+- PR #12 is stacked on PR #8’s branch, not on `main`.
+- PR #12’s visual review is preview-ok.
 
-| PR | Branch | Scope | Ship as-is? | Review status |
-|---:|---|---|---|---|
-| **#2** | `cursor/design-theory-review-465c` | Docs only: skeptical design-theory review of `main`, recovery-path scorecard, generic-first direction, desktop pick, observer boundaries, human/no-human decision split, and a 0–10 PR-sequence (`docs/design-theory-review.md`, `docs/pr-sequence.md`). No runtime change. | **Yes — docs-only.** | Self-described authorized second-opinion review; changes no behavior. Mergeable as documentation; owner/design sign-off is the only gate. |
-| **#3** | `cursor/genericity-audit-966b` | Docs only: inventory of **85 findings** where code assumes a specific variant, compiler, OS/CPU, or decompiler output shape (`docs/genericity-audit.md`). Facts only, no fix. | **Yes — docs-only.** | Factual inventory; nothing is "fixed" by it. Mergeable as a reference for later generality work. |
-| **#4** | `cursor/generic-first-discovery-ca12` | Code: generic method discovery from JNI structure (vtable index 215 via decoded operands, ABI arg registers, `Java_*` exports), Ghidra demoted to an optional method-body plugin, new `static-lite`/`inventory`-style commands, schema additions, tests + a real ELF fixture (`docs/reviews/generic-first-pr.md`, `docs/generic-recovery.md`). | **As a draft / dev merge: yes. As the default release: no.** | Reviewed twice. Both original must-fixes resolved (real-ELF loading test committed; lifter derives profile from the artifact). Full Python suite 21 passed. Residual (not must-fix): unnamed count-only positional mis-binding; PE/Mach-O loading unproven; section-stripped ELF returns a silent empty registry. |
-| **#5** | `cursor/platform-plan-docs-7274` | Docs only: a second, independent platform plan plus ADR-style decision records that split "decisions this plan makes" (D1–D11) from "decisions reserved for a human" (B1–B11), and a cross-check against #2 (`docs/platform-plan.md`, `docs/decisions.md`, `docs/plan-crosscheck.md`). | **Yes — docs-only.** | Endorses #2's diagnosis; differs on sequencing (front-load decision-free value; defer the event-IR/fusion rebuild). Mergeable as documentation. |
-| **#6** | `cursor/cli-doctor-setup-getting-started-b8b1` | Code: read-only `doctor` preflight, `setup.sh`/`setup.ps1`, `j2c` launchers, bilingual getting-started, Ghidra-free tests; both READMEs reframed so manual CLI is the default and assisted adaptation is optional (`docs/reviews/cli-doctor-setup.md`). | **Ship as draft; final nit pass.** | The original 7 must-fix items are resolved. What remains is a **final nit pass**: the README still shows leftover `python -m` examples, `doctor` on ARM must not report an ARM-labelled leftover agent as OK, and the README intro still over-claims "real bytecode bodies." Merge once those nits close. |
-| **#7** | `cursor/native-x86-plugin-abi-5384` | Docs + skeleton: a separate user-mode `native-x86/` module (owned-process/module enumeration, PE/ELF inspection, scoped instrumentation — **none implemented yet**), a versioned C plugin ABI whose public header carries **no Java/JNI types**, and a boundary doc for an optional, unimplemented privileged observer (`docs/reviews/native-x86-abi.md`, `docs/plugin-abi.md`, `docs/privileged-observer.md`). | **Ship as a documentation + experimental skeleton.** | After must-fix + re-review: the earlier must-fixes (minor-version negotiation memory overwrite, `process_id` mislabeling, overclaimed lifecycle/transport) are addressed. **ABI v0.1 is explicitly experimental/unstable and is not a product feature.** Java/JNI isolation, recovery-pipeline isolation, and the Linux smoke build pass. |
-| **#8** | `cursor/swing-desktop-viewer-7389` | Code: an optional read-only Swing + FlatLaf desktop viewer that launches CLI stages and renders pipeline status, the method table, and JVMTI trace — **no recovery logic, no browser server** (`docs/reviews/desktop-ui-visual.md`, `jvm/desktop-ui/README.md`). | **Yes, optional desktop draft** — not a formal UI ship. | Visual pass is **done**: it found and fixed 6 issues (clipped detail pane, mid-token command wrap, centered headers, jumping divider, non-reproducible screenshots) and **removed a permanently-disabled "Attach — not available yet" button**. `:desktop-ui:test` passes. Remaining item is the JDK split — the module targets JDK 21 while the rest of `jvm/` targets JDK 17. This is an optional desktop draft, not a formal UI ship. |
-| **#9** | `cursor/opt-in-jvmti-live-attach-1155` | Code: opt-in live attach preview — export `Agent_OnAttach`, a `jdk.attach` **same-user** CLI (`--i-own-this-process` + required explicit `--pid`), lazy per-thread install, capability/gap/drop records over the existing agent; default `recover` (startup `-agentpath`) unchanged (`docs/reviews/jvm-attach.md`, `docs/jvm-attach.md`). | **Ship as a preview draft** — not default recover. | After must-fix + re-review: the three must-fixes (`jcmd` false success on load failure, coverage claims exceeding what a live attach obtains, and a dead `--log-all` switch) are resolved. Empirically on OpenJDK 21 a live attach is **often bind-only** (`native-method-bind`); entry/exit/locals/exception are `OnLoad`-only, so records and docs were corrected to say so. Full method-body recovery still needs the startup path. |
+The consequence is that #12 must follow #8, and the desktop toolchain split must
+remain explicit rather than silently changing the repository baseline.
 
----
+### JVMTI attach (#9)
 
-## 2. What is true now versus what the original repo claimed
+- Attach is opt-in and uses the existing same-user plus explicit confirmation
+  policy.
+- On OpenJDK 21, live attach is often bind-only.
+- Startup `-agentpath` remains the default recovery path.
 
-Each row states the **original claim** (from `main`'s README/architecture docs),
-what the draft PRs make **true now** (on their branches, not yet on `main`), and
-the **gap** an owner should keep in mind.
+The consequence is that attach can ship as a preview, but the GUI and CLI must
+display the capability actually obtained and must not imply startup-equivalent
+coverage.
 
-### 2.1 Generic-first
+### Optional privileged observer (#11)
 
-- **Original claim.** The core is "obfuscator-agnostic," with variant knowledge
-  confined to profiles and architecture modules, and the core "never branches on
-  a named producer."
-- **True now.** Only the standards-derived kernel is genuinely generic: JNI ABI
-  constants, `RegisterNatives` semantics, versioned JSON artifacts, and the ASM
-  emitter. #3 documents 85 places where producer/compiler/OS/decompiler shape is
-  assumed outside `Profile`. #4 adds a genuinely generic discovery path
-  (structural `RegisterNatives` detection + ABI arg registers + `Java_*` exports)
-  and proves the ELF loading path in CI.
-- **Gap.** #4 is a draft, not the default and not merged. On `main` the static
-  lifter, cache-table scanner, string-pool scoring, loader detection, and rebuild
-  cleanup remain variant/OS-coupled. The correct summary is "standards-derived
-  primitives plus some extension points," not "agnostic end to end."
+- The current scope is a documentation mock.
+- Linux behavior is a userspace maps mock only.
+- There is no kernel source, build target, image, or shipped kernel component.
 
-### 2.2 Ghidra optional
+The consequence is that the contract can be reviewed without creating a kernel
+maintenance or deployment commitment. The recommended default remains **no**.
 
-- **Original claim.** The static path "requires Ghidra"; static coverage tables
-  read as near-complete.
-- **True now.** #4 demotes Ghidra to an optional method-body plugin in help text,
-  stub notes, the `static-reverse` command, both READMEs, and
-  `docs/generic-recovery.md`; discovery, manifest, and restoration stubs are
-  produced with no decompiler. #6 labels Ghidra "Advanced / optional" and its new
-  tests run without it. #5/#2 mark the stale static-approach doc for correction.
-- **Gap.** Not yet on `main`. The one remaining "requires Ghidra" string (in
-  `docs/ROADMAP.md`) accurately describes a CI limitation of the static-path
-  end-to-end tests, not a hard tool requirement.
+## Human decision table
 
-### 2.3 Usage barrier
+These are decisions, not implementation questions. Each row records the options,
+the recommendation, and the consequence of adopting it.
 
-- **Original claim.** "The best way to use this project is to drive it with a
-  coding agent… don't expect to just run the ready-made scripts by hand."
-- **True now.** #6 adds a read-only `doctor` preflight, `setup.sh`/`setup.ps1`,
-  `j2c` launchers, and a bilingual getting-started guide, and reframes both
-  READMEs so **manual CLI use is the default** and assisted adaptation is
-  optional.
-- **Gap.** Not merged. Its original 7 must-fix items are resolved; a **final nit
-  pass** remains (leftover `python -m` examples in the README, `doctor` on ARM not
-  OK-ing an ARM-labelled leftover agent, and a README intro that still over-claims
-  "real bytecode bodies"). The barrier is lowered on the branch and close to
-  merge-ready.
-
-### 2.4 GUI
-
-- **Original claim.** None — the repo shipped only auto-generated static
-  screenshots.
-- **True now.** #8 adds an optional read-only desktop viewer (Swing + FlatLaf)
-  that is strictly a client of the CLI: it launches stages and renders their JSON
-  (pipeline status, method table, trace) and contains no recovery logic and no
-  browser server.
-- **Gap.** It waits on stable CLI/event contracts, and the module targets JDK 21
-  while the rest of `jvm/` targets JDK 17 (a toolchain split to resolve).
-
-### 2.5 Attach
-
-- **Original claim.** The CLI's "attach" wording actually meant launching a new
-  process with `-agentpath`; the agent had `Agent_OnLoad`/`Agent_OnUnload` but no
-  `Agent_OnAttach`, and initialized on `VMInit` (already past in a running JVM).
-- **True now.** #9 adds a real live-attach **preview**: `Agent_OnAttach`, a
-  `jdk.attach` same-user CLI gated by `--i-own-this-process` and a required
-  explicit `--pid`, lazy per-thread install, and honest capability/gap/drop
-  records. The default `recover` path is unchanged.
-- **Gap.** Live attach is JVM-limited: on OpenJDK 21 it obtains only
-  native-method-bind; entry/exit/locals/exception are `OnLoad`-only. Full
-  method-body recovery still requires the startup `-agentpath` path. Threads
-  already running at attach time never get per-JNI-call argument capture (reported
-  as a gap record).
-
-### 2.6 Native-x86 isolation
-
-- **Original claim.** The only native component was `native/` — the in-process
-  JVMTI agent.
-- **True now.** #7 adds a separate `native-x86/` user-mode module with a versioned
-  C plugin ABI whose public header carries **no Java/JNI types** (verified), and
-  keeps the recovery pipeline (`py/`, `jvm/`, `native/`, `ghidra/`) untouched. A
-  future JVM adapter is documented as living *outside* this directory.
-- **Gap.** It is a **skeleton plus documentation** — no process observation or
-  instrumentation is implemented. After re-review the earlier memory-safety and
-  labeling must-fix items are resolved (see §3.5); **ABI v0.1 remains explicitly
-  experimental and is not a product feature**, and the out-of-process transport /
-  wire schema is still future work rather than a property the skeleton enforces.
-
----
-
-## 3. Human decisions still open
-
-For each: the concrete options, the recommendation carried by the reviews, the
-consequences, and **whether work already proceeded** on the recommended option.
-These are the decisions the reviews explicitly reserve for a human because they
-commit the project to user expectations, security policy, toolchains, or
-long-term maintenance.
-
-### 3.1 Meaning of "restored" and the default partial-output policy
-
-- **Options — "restored".** (A) decompilable; (B) verifier-clean; (C)
-  verifier-clean **plus** method coverage and behavior checks.
-- **Options — partial output.** (A) strip native resources anyway; (B) emit a
-  hybrid runnable JAR by default; (C) evidence-only.
-- **Recommendation.** "Restored" = (C), with separate **`hybrid`** and
-  **`inspection-only`** labels. Partial output = (B) by default; (C) only when
-  safe retention is impossible. A verifier-clean body full of synthetic defaults
-  is still **partial**, and a "clean JAR" that is non-loadable must never be
-  called restored.
-- **Consequences.** A higher, clearer bar per "restored" claim and partial
-  results that stay runnable, at the cost of a slightly more complex default
-  artifact and a migration of today's "clean JAR" wording.
-- **Work already proceeded?** **No — and this is the most important open gap.**
-  Today's rebuilder can strip the loader/native blob while methods remain stubbed,
-  and artifacts do not yet carry source/confidence. The reviews recommend adding
-  additive `source`/`confidence`/`capability` fields and an *opt-in* hybrid mode
-  first, and deferring the **default** policy flip until this decision is made. No
-  branch in this set flips the default; #4's review flags the strip-while-stubbed
-  behavior as a should-fix.
-
-### 3.2 Desktop stack
-
-- **Options.** Swing + FlatLaf; JavaFX; Compose Desktop.
-- **Recommendation.** **Swing + FlatLaf** — it reuses the existing JVM/Gradle
-  build, `java.desktop` ships with the JDK, the workload is tables/trees/log
-  streams, and packaging (`jlink`/`jpackage`) can wait until the module is stable.
-  A browser interface is explicitly out of scope.
-- **Consequences.** Small, JDK-native footprint; an imperative UI style that needs
-  disciplined event-dispatch-thread handling.
-- **Work already proceeded?** **Yes — confirm.** #8 already built the viewer on
-  Swing + FlatLaf as a read-only CLI client, with the visual review's fixes
-  applied and tests passing. The open sub-item is the JDK 17/21 toolchain split,
-  not the toolkit choice. Recommendation: **confirm Swing + FlatLaf** and scope
-  JDK 21 to the desktop module only.
-
-### 3.3 Live attach policy
-
-- **Options.** Any accessible PID; same-user + explicit PID confirmation; explicit
-  allowlist.
-- **Recommendation.** **Same-user + explicit PID confirmation**, while allowing a
-  stricter enterprise policy. Never conceal the agent, never patch attach checks;
-  offer documented modes (startup `-agentpath`, offline emulation, user-mode
-  observation) when a target disables or detects attach.
-- **Consequences.** A safe default; power users on shared hosts need extra
-  configuration. Process access is a security/product policy, not an
-  implementation detail.
-- **Work already proceeded?** **Yes — as a preview.** #9 implements same-user +
-  `--i-own-this-process` + required explicit `--pid`, retains the same-user /
-  looks-like-Java validation, and adds no stealth/evasion/kernel/TLS behavior. The
-  open decision is whether to keep it same-user by default (recommended) and
-  whether to add an enterprise allowlist; the implementation must remain an
-  **opt-in preview** until the JVM/concurrency/privacy/security review clears it.
-
-### 3.4 Whether native-x86 stays in this repository
-
-- **Options.** Keep it in this repository (isolated); split it into a separate
-  project.
-- **Recommendation.** **Keep it in-repo but strictly isolated** for now: no
-  dependency from the recovery pipeline into `native-x86/`, no Java/JNI types in
-  its public ABI, and any JVM adapter placed outside the directory. Revisit a
-  split only if the module grows its own release cadence.
-- **Consequences.** Keeping it in-repo keeps one review surface and shared CI;
-  splitting later is cheap **because** the isolation rules are enforced now.
-  Letting the boundary blur would make a later split expensive.
-- **Work already proceeded?** **Partially.** The skeleton already lives in-repo
-  and is isolated (recovery pipeline untouched; Java/JNI isolation verified). The
-  keep-vs-split call itself remains open and is listed as a human decision in #7's
-  review.
-
-### 3.5 Plugin trust and transport
-
-- **Options — ABI stability.** Unstable C++; **versioned C ABI**; a
-  language-specific in-process API.
-- **Options — trust.** Trust plugins in-process; require out-of-process isolation.
-- **Options — transport.** In-process only; a defined out-of-process wire schema.
-- **Recommendation.** A **versioned C ABI** (opaque handles, explicit `size` /
-  `abi_version` fields, host-owned allocators, bounded/redaction-aware events),
-  **frozen only after two real plugins exist**. Treat the in-process path as the
-  starting point and **define a real wire schema before claiming out-of-process
-  transport**. Decide trust explicitly rather than defaulting to in-process trust.
-- **Consequences.** A stable, long-lived extension point, but ABI compatibility
-  becomes a maintenance obligation, so the freeze is deliberately evidence-gated.
-- **Work already proceeded?** **Partially.** #7 publishes the C ABI design and a
-  working skeleton, and after re-review the earlier defects (minor-version
-  negotiation memory overwrite, `process_id` mislabeling, and overclaimed
-  lifecycle/transport) are addressed. **ABI v0.1 is explicitly experimental — not
-  frozen, and not a product feature.** A real out-of-process wire schema and the
-  trust model (in-process trust versus isolation) remain open and are left to a
-  human; the freeze still waits for two real plugins.
-
-### 3.6 Whether a privileged observer should ever be built
-
-- **Options.** Make it a foundation; do early parallel work; treat it as a later,
-  optional, gated component.
-- **Recommendation.** **Default: no.** Only a **later optional gate**, and only
-  after user-mode telemetry demonstrates a concrete, repeated visibility gap that
-  user-mode observation provably cannot serve, with maintainer-approved threat and
-  support models. The user would enable OS debug/test-signing themselves; **the
-  project ships no signed driver**, automates no security-weakening step, and adds
-  no stealth, no signature/integrity bypass, no hidden loaders, no interception,
-  and no data exfiltration. It would emit the *same* neutral records as the
-  user-mode path behind the *same* plugin ABI.
-- **Consequences.** Keeps system-wide crash/blast-radius, per-kernel maintenance,
-  and un-CI-able configurations out of the default path. The cost is high,
-  permanent, and paid by maintainers; the benefit is narrow.
-- **Work already proceeded?** **No, by design.** Only a boundary document exists
-  (`docs/privileged-observer.md`): no kernel source, driver project, build target,
-  or binary. Nothing in the default workflow, method inventory, GUI, or plugin ABI
-  depends on it. This matches the recommendation; keep it doc-only until the bar
-  is met.
-
-### 3.7 Sensitive buffer / library observation
-
-- **Options.** Always capture buffer/key contents; **metadata-only**; explicit
-  content opt-in.
-- **Recommendation.** **Metadata-only by default** (function identity, sizes,
-  algorithm identifiers, return status, call correlation). Any content capture
-  must be a separate, per-session, **local-only**, redaction-aware, explicitly
-  indicated option with a retention policy and **no remote upload**. Well-known
-  cryptographic entry points may be *named* as points of interest; hooking them is
-  a later opt-in plugin, not a default.
-- **Consequences.** A safe default posture; full-content diagnostics require a
-  deliberate switch and a redaction/retention policy, because buffers can contain
-  credentials and personal data.
-- **Work already proceeded?** **No — not implemented (correctly).** The
-  `native-x86/` records are structural metadata only; there is no buffer or key
-  capture, and the crypto-library plugins + JVM bridge are a later, gated,
-  still-unbuilt step. If content observation is ever built, it must be metadata-only
-  by default with content strictly opt-in as above.
-
-### 3.8 Other reserved decisions (for completeness)
-
-These also require a human but were not called out individually in the task.
-
-| Decision | Options | Recommendation | Work proceeded? |
+| Decision | Options | Recommendation | Consequence |
 |---|---|---|---|
-| Event-IR + evidence-fusion: now or later | build now as the new core; defer behind additive provenance fields | **Defer**; formalize a shared event schema only after two real producers (emulation + live attach) need it | No — additive fields recommended first; the fusion subsystem is deliberately deferred |
-| First supported platform set | Windows x64 only; **Windows + Linux x64**; all formats/arches | Windows + Linux x64 user mode first (matches current two x86-64 ABI modules) | Matches current coverage; AArch64/macOS deferred |
-| Cross-language producer knowledge | port the Python `Profile` into the JVM modules; a shared producer-hints JSON; leave duplicated | **Shared producer-hints JSON** consumed by both the Python profile layer and the two Kotlin modules | No — proposed only |
-| Dependency distribution | bundle everything; download at runtime; **bundle GUI/runtime, user supplies Ghidra** | Bundle GUI/runtime; user supplies optional Ghidra | No — proposed only |
+| Meaning of **“restored”** | Verifier-clean; verifier-clean with coverage evidence; verified coverage plus behavior checks. | Reserve “restored” for verified coverage plus behavior checks. Label lesser results explicitly. | Claims become auditable; existing output labels and acceptance checks may need migration. |
+| Default for partial output | Hybrid runnable JAR; inspection-only artifact; strip native resources while stubs remain. | Default to **hybrid** when it can remain runnable; otherwise produce an explicitly labeled **inspection-only** artifact. Do not call either fully restored without the evidence above. | Safer partial results and clearer user expectations, at the cost of retaining native material in hybrid output and maintaining two explicit states. |
+| Desktop toolkit | Swing + FlatLaf; JavaFX; Compose Desktop. | **Confirm Swing + FlatLaf.** | Keeps the implemented #8 path and avoids a toolkit restart; the JDK 21 module boundary still requires review against the JDK 17 baseline. |
+| Attach policy | Any accessible process; same-user plus explicit confirmation; administrator allowlist. | Keep the already implemented **same-user plus confirmation flag** default; permit stricter deployment policy. | Preserves explicit consent and a narrow access boundary; does not remove JVM capability limits. |
+| Native-x86 repository placement | Keep isolated in this repository; split into a separate repository. | Keep it in-repo while enforcing the existing isolation, and revisit only if release cadence or ownership diverges. | Shared review and CI remain simple; strict boundaries preserve a later split option. |
+| Plugin trust and transport | Trusted in-process plugins; isolated plugins with an out-of-process protocol; support both. | Keep the ABI versioned and preview-only, define trust explicitly, and freeze transport only after real plugin evidence exists. | Avoids prematurely freezing unsafe trust or transport assumptions; stable compatibility is deferred. |
+| Privileged observer default | Default component; optional component; no shipped component. | **Default: no.** Keep #11 as a docs mock unless repeated userspace evidence proves a specific unmet need and a separate approval is made. | Avoids kernel support and deployment risk; any future exception requires new evidence and review. |
+| Cryptographic library observation | Content capture; metadata-only; metadata by default with content opt-in. | **Metadata-only.** | Preserves useful call, size, status, and correlation evidence without collecting sensitive content. |
 
----
+## What is still not true
 
-## 4. Suggested merge order for the draft PRs
+- The generic path is **not** the default release path.
+- Live attach is **not** equivalent to startup instrumentation and is often
+  bind-only on OpenJDK 21.
+- The GUI does **not** replace the CLI as the automation or recovery contract.
+- Native-x86 is a **preview draft**, not a product feature.
+- The kernel path is **documentation plus a Linux userspace maps mock**; no
+  kernel implementation is shipped.
+- None of PRs #2–#12 is merged; GitHub currently shows every one as an open
+  draft.
 
-The order deliberately establishes **truthful docs and lowered setup friction
-before** adding more front ends or observers. Docs branches are mergeable now
-(owner sign-off aside); code branches merge only after their review gates clear.
+## Recommended merge order
 
-1. **Docs first — #2, #3, #5 (+ this report, #10).** Docs-only; they change no
-   runtime behavior and set the contracts and honest labels everything else
-   references. Merge in any order among themselves.
-2. **#6 — doctor / setup / getting-started.** After its **final nit pass** closes
-   (leftover `python -m` examples, ARM `doctor` not OK-ing an ARM-labelled leftover
-   agent, the "real bytecode bodies" README over-claim). It removes the largest
-   usage barrier and is a prerequisite for a good first-run experience.
-3. **#4 — generic-first discovery.** As a **draft / development merge**, not as
-   the default release path. It proves the generic front door (ELF verified).
-4. **#8 — Swing desktop viewer.** An **optional desktop draft** (not a formal UI
-   ship), after the CLI/event contracts it consumes are stable; visual fixes are
-   already applied.
-5. **#9 — live attach.** Kept a **preview draft**; the default `recover` path stays
-   on startup `-agentpath`.
-6. **#7 — native-x86 core + plugin ABI.** As a **documentation + experimental
-   skeleton** after its must-fix + re-review — ABI v0.1 is experimental and not a
-   product feature.
+1. **#2 / #3 / #5 / #10** — documentation first, in any order within the group.
+2. **#6** — setup, `doctor`, launchers, and getting started; keep JDK 17.
+3. **#4** — draft/development generic discovery, explicitly not the default.
+4. **#8** — optional desktop artifact viewer.
+5. **#12** — only after #8, because #12 is based on #8’s branch.
+6. **#9** — opt-in JVMTI attach preview.
+7. **#7** — native-x86 preview, after the main documentation set.
+8. **#11** — last, because of the `docs/privileged-observer.md` overlap with #7.
 
-### What must not be merged / promoted until its review says so
+## Promotion gates
 
-- **#4 must not become the default release path** until the unnamed **count-only
-  positional mis-binding** is closed (it silently binds a stack table to the first
-  class with a matching native-method count); PE (`.dll`) and Mach-O loading paths
-  should also be proven by committed fixtures.
-- **#6 must not merge** until its final nit pass closes: the leftover `python -m`
-  examples in the README, `doctor` on ARM reporting an ARM-labelled leftover agent
-  as OK, and the README intro that still over-claims "real bytecode bodies." (The
-  original 7 must-fix items are already resolved.)
-- **#7's ABI v0.1 is experimental and must not be treated as a stable ABI or a
-  product feature.** The earlier defects (minor-version negotiation memory
-  overwrite, `process_id` mislabeling, overclaimed lifecycle/transport) are fixed;
-  it ships as a documentation + experimental skeleton, and a real out-of-process
-  wire schema plus the freeze (after two real plugins) remain future work.
-- **#9 must stay an opt-in preview**; it must not be promoted to the default
-  `recover` path and must not claim entry/exit/locals/exception coverage unless the
-  per-capability record reports it available.
-- **No branch may label output "restored" from an inspection-only or verifier-only
-  artifact**, and the default output policy must not be flipped, until the meaning
-  of "restored" and the partial-output policy (§3.1) are decided.
-- **Sensitive buffer/library-content capture and any privileged observer must not
-  be built** until their human decisions (§3.6, §3.7) are made.
+- #4 needs committed PE, Mach-O, and stripped-ELF evidence before broad platform
+  or default-release claims.
+- #7 needs explicit plugin trust and transport decisions, additional platform
+  evidence, and a separate promotion review before it can move beyond preview.
+- #8/#12 must keep their JDK 21 requirement module-local unless the repository
+  separately approves a baseline migration.
+- #9/#12 must report actual attach capabilities and retain startup `-agentpath`
+  as the default recovery path.
+- #11 must remain documentation plus userspace mock behavior unless the
+  privileged-observer decision is explicitly changed with supporting evidence.
 
----
-
-## 5. Explicitly out of scope / not done
-
-The following are **not implemented anywhere** in these branches, exist only as
-boundary or "future plugin" documentation, and must not be built before their
-corresponding human decisions are made:
-
-- **Real user-mode cryptographic-library instrumentation with content capture.**
-  Well-known entry points may be *named* as points of interest; the crypto-library
-  plugins and the JVM bridge are a later, gated, unbuilt step. Default remains
-  metadata-only.
-- **Kernel driver / privileged observer implementation.** Documentation-only
-  boundary (`docs/privileged-observer.md`): no kernel source, driver project,
-  build target, or binary. Default is user mode; the project ships no signed
-  driver.
-- **Any Web / browser interface.** Explicitly vetoed. The only UI is the optional
-  read-only desktop viewer (#8); the CLI remains the sole automation contract.
-
-This report itself implements no product feature and is docs-only.
+This report records current choices and consequences; it does not itself change
+any runtime default.

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -14,7 +14,7 @@ Keep the command-line recovery path as the automation contract. Merge truthful
 documentation and setup work first, then add the generic discovery path only as
 a development draft. Layer the optional desktop work and JVMTI attach preview
 after their dependencies. Treat native-x86 as a preview draft rather than a
-product feature, and merge the privileged-observer documentation mock last.
+product feature, and merge the privileged-observer userspace preview last.
 
 Nothing in the current drafts justifies making generic discovery, live attach,
 native-x86, or privileged observation a default release path.
@@ -29,25 +29,32 @@ review can be skipped.
 |---:|---|---|---|
 | **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
-| **#4** | Generic-first discovery. The count-only silent misbind is closed. PE, Mach-O, and stripped-ELF behavior remain unproven. | **Yes, as a draft/development path; not as the default release.** | Yes, before any default promotion and when adding evidence for the unproven formats. |
+| **#4** | Generic-first discovery at `864f1a427c1fa30071733cfe09440cbbe6c6a483`. Committed x86-64 fixtures now cover real PE, Mach-O, stripped ELF without `.symtab`, and exports-only ELF; pytest reports 27 passed. Ambiguous count-only cases still use `bindingGaps`, and `recover` keeps its existing default. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Non-x86-64, section-header-removed ELF, and encrypted or shuffled tables remain unproven. |
 | **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#6** | `doctor`, setup scripts, launchers, and getting-started material. JDK 17 is retained. | **Yes, as a draft.** | Normal merge review remains; no JDK migration is implied. |
 | **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `8b9231c145e80acbc723fbc893d072398cba143b`, after multiple must-fix rounds. | **Yes, as a preview draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. The current preview verdict is supported by the completed review rounds and smoke evidence. |
 | **#8** | Optional Swing + FlatLaf artifact viewer. The visual pass is complete. The desktop module uses JDK 21 while the repository baseline remains JDK 17. | **Yes, as an optional desktop draft.** | Yes, principally for the JDK 21 module boundary and normal merge review. |
-| **#9** | Opt-in JVMTI attach. OpenJDK 21 live attach is often bind-only; default recovery remains startup `-agentpath`. | **Yes, as a preview draft only.** | Yes before any capability or default-policy expansion. |
+| **#9** | Opt-in JVMTI attach at `1a8cea87e8882fd48df8c00c5034021e23ccdaf3`. Common attach refusals are classified, there is no stealth or bypass behavior, and default recovery remains startup `-agentpath`. | **Yes: ship-as-preview-draft.** | Two review nits remain: `allowAttachSelf=false` governs self-attach and must not hard-refuse an external CLI, and pre-validation should print reason codes. Review remains required before capability or default-policy expansion. |
 | **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
-| **#11** | Optional privileged-observer contract. It is a documentation mock with Linux userspace maps mock behavior only and no kernel source. | **Yes, as a docs mock only.** | Yes before any implementation work; the default remains no privileged observer. |
+| **#11** | Optional privileged observer at `dc30188118a6579c024978fa9ff52ca154012170`, with a versioned plugin ABI and Linux maps backend. It is default-off userspace code with no kernel files. | **Yes: ship-as-preview-userspace.** | Yes for later promotion and merge-order integration with #7. It is not a kernel feature, and the default remains **no**. |
 | **#12** | Desktop live-attach/listen GUI, based on PR #8’s branch rather than `main`. Visual review is preview-ok. | **Yes, as a preview after #8.** | Yes for integration review after #8 and for the same attach limitations as #9. |
 
 ## Current evidence and boundaries
 
 ### Generic-first discovery (#4)
 
-- The earlier count-only silent misbind is closed.
-- The branch can be used as a draft/development path.
+- The reviewed revision is
+  `864f1a427c1fa30071733cfe09440cbbe6c6a483`.
+- Committed x86-64 fixtures exercise real PE, Mach-O, stripped ELF without
+  `.symtab`, and exports-only ELF images.
+- The independent review run reports `pytest`: 27 passed.
+- Ambiguous count-only matching is represented with `bindingGaps`; it is not
+  silently treated as a complete binding.
+- The branch can ship as a draft/development path.
+- The `recover` default is unchanged.
 - It is not the default release path.
-- PE and Mach-O loading are not yet proven by committed evidence.
-- Stripped-ELF behavior is not yet proven.
+- Non-x86-64 binaries, ELF images with section headers removed, and encrypted
+  or shuffled tables remain unproven.
 
 The consequence is deliberate: developers can continue validating the generic
 path without presenting incomplete platform coverage as a released default.
@@ -98,10 +105,17 @@ remain explicit rather than silently changing the repository baseline.
 
 ### JVMTI attach (#9)
 
+- The reviewed revision is
+  `1a8cea87e8882fd48df8c00c5034021e23ccdaf3`.
 - Attach is opt-in and uses the existing same-user plus explicit confirmation
   policy.
+- Common attach refusals are classified.
+- There is no stealth or bypass behavior.
 - On OpenJDK 21, live attach is often bind-only.
 - Startup `-agentpath` remains the default recovery path.
+- Outstanding review nit: `allowAttachSelf=false` controls JVM self-attach; it
+  should not cause the external CLI to hard-refuse an attach attempt.
+- Outstanding review nit: pre-validation should print its reason codes.
 
 The consequence is that attach can ship as a preview, but the GUI and CLI must
 display the capability actually obtained and must not imply startup-equivalent
@@ -109,11 +123,15 @@ coverage.
 
 ### Optional privileged observer (#11)
 
-- The current scope is a documentation mock.
-- Linux behavior is a userspace maps mock only.
-- There is no kernel source, build target, image, or shipped kernel component.
+- The reviewed revision is
+  `dc30188118a6579c024978fa9ff52ca154012170`.
+- The branch implements a versioned plugin ABI and a Linux maps backend.
+- It is an opt-in userspace preview and remains off by default.
+- There are no kernel files or shipped kernel components; this is not a kernel
+  feature.
+- Its `docs/privileged-observer.md` overlap with #7 remains a merge-order issue.
 
-The consequence is that the contract can be reviewed without creating a kernel
+The consequence is **ship-as-preview-userspace**, without creating a kernel
 maintenance or deployment commitment. The recommended default remains **no**.
 
 ## Human decision table
@@ -129,7 +147,7 @@ the recommendation, and the consequence of adopting it.
 | Attach policy | Any accessible process; same-user plus explicit confirmation; administrator allowlist. | Keep the already implemented **same-user plus confirmation flag** default; permit stricter deployment policy. | Preserves explicit consent and a narrow access boundary; does not remove JVM capability limits. |
 | Native-x86 repository placement | Keep isolated in this repository; split into a separate repository. | Keep it in-repo while enforcing the existing isolation, and revisit only if release cadence or ownership diverges. | Shared review and CI remain simple; strict boundaries preserve a later split option. |
 | Plugin trust and transport | Trusted in-process plugins; isolated plugins with an out-of-process protocol; support both. | Keep the ABI versioned and preview-only, define trust explicitly, and freeze transport only after real plugin evidence exists. | Avoids prematurely freezing unsafe trust or transport assumptions; stable compatibility is deferred. |
-| Privileged observer default | Default component; optional component; no shipped component. | **Default: no.** Keep #11 as a docs mock unless repeated userspace evidence proves a specific unmet need and a separate approval is made. | Avoids kernel support and deployment risk; any future exception requires new evidence and review. |
+| Privileged observer default | Default component; opt-in userspace preview; no shipped component. | **Default: no.** Permit #11 only as an explicitly enabled userspace preview; do not represent it as a kernel feature. | Preserves the versioned ABI and Linux maps evidence without creating kernel support or default deployment risk; promotion still requires separate evidence and review. |
 | Cryptographic library observation | Content capture; metadata-only; metadata by default with content opt-in. | **Metadata-only.** | Preserves useful call, size, status, and correlation evidence without collecting sensitive content. |
 
 ## What is still not true
@@ -137,10 +155,11 @@ the recommendation, and the consequence of adopting it.
 - The generic path is **not** the default release path.
 - Live attach is **not** equivalent to startup instrumentation and is often
   bind-only on OpenJDK 21.
+- Live attach does **not** provide stealth or bypass behavior.
 - The GUI does **not** replace the CLI as the automation or recovery contract.
 - Native-x86 is a **preview draft**, not a product feature.
-- The kernel path is **documentation plus a Linux userspace maps mock**; no
-  kernel implementation is shipped.
+- The privileged observer is an **opt-in userspace preview**, not a kernel
+  feature; it has no kernel files and is not enabled by default.
 - None of PRs #2–#12 is merged; GitHub currently shows every one as an open
   draft.
 
@@ -157,16 +176,20 @@ the recommendation, and the consequence of adopting it.
 
 ## Promotion gates
 
-- #4 needs committed PE, Mach-O, and stripped-ELF evidence before broad platform
-  or default-release claims.
+- #4 now has committed x86-64 PE, Mach-O, stripped-ELF-without-`.symtab`, and
+  exports-only ELF fixtures. Default promotion remains blocked on non-x86-64
+  evidence and more incomplete images, including section-header-removed ELF and
+  encrypted or shuffled tables.
 - #7 needs explicit plugin trust and transport decisions, additional platform
   evidence, and a separate promotion review before it can move beyond preview.
 - #8/#12 must keep their JDK 21 requirement module-local unless the repository
   separately approves a baseline migration.
 - #9/#12 must report actual attach capabilities and retain startup `-agentpath`
-  as the default recovery path.
-- #11 must remain documentation plus userspace mock behavior unless the
-  privileged-observer decision is explicitly changed with supporting evidence.
+  as the default recovery path. #9 should also correct the `allowAttachSelf`
+  pre-check and print pre-validation reason codes.
+- #11 is a userspace preview with a versioned plugin ABI and Linux maps backend.
+  It must remain default-off, and any promotion or kernel scope requires a
+  separate decision backed by new evidence.
 
 This report records current choices and consequences; it does not itself change
 any runtime default.

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -1,6 +1,6 @@
 # Options and status report for JNI-native recovery platform work
 
-> Status checked against GitHub on 2026-08-29. Pull requests #2 through #12 are
+> Status checked against GitHub on 2026-08-29. Pull requests #2 through #13 are
 > all open, unmerged drafts. This report is documentation only; it does not
 > implement or promote a product feature.
 >
@@ -29,28 +29,30 @@ review can be skipped.
 |---:|---|---|---|
 | **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
-| **#4** | Generic-first discovery at `d6d2637a8aee382c409844603a0631f4197d6e1f`. In addition to the x86-64 formats, committed fixtures now prove real AArch64 ELF and section-header-removed ELF mapped from `PT_LOAD`; independent review confirmed the AArch64 image and zero section headers. Pytest covers at least 23 introspection-and-merge cases, and the implementer reports 31 passing in the full suite. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Mach-O arm64, 32-bit ARM, and encrypted or shuffled tables remain unproven. |
+| **#4** | Generic-first discovery at `5d43cd4508118c8f385bbf5606a9d15cd0a2e41d`. In addition to the x86-64 formats, committed fixtures prove real AArch64 ELF, section-header-removed ELF mapped from `PT_LOAD`, and a real Mach-O arm64 dylib. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. 32-bit ARM and encrypted or shuffled tables remain unproven. |
 | **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#6** | `doctor`, setup scripts, launchers, and getting-started material. JDK 17 is retained. | **Yes, as a draft.** | Normal merge review remains; no JDK migration is implied. |
-| **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `8b9231c145e80acbc723fbc893d072398cba143b`, after multiple must-fix rounds. | **Yes, as a preview draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. The current preview verdict is supported by the completed review rounds and smoke evidence. |
+| **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `1817e2d664b0a72269f188cbc4a9ddc342b62f0a`. Linux smoke passes sections 1–15. Windows supports read-only module/export observation, with no live breakpoints. No kernel component is shipped. | **Yes: ship-as-preview-draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. |
 | **#8** | Optional Swing + FlatLaf artifact viewer. The visual pass is complete. The desktop module uses JDK 21 while the repository baseline remains JDK 17. | **Yes, as an optional desktop draft.** | Yes, principally for the JDK 21 module boundary and normal merge review. |
 | **#9** | Opt-in JVMTI attach at `f7664e46f89b83bc6ffb6c3680193412c8cbff36`. Common attach refusals are classified, there is no stealth or bypass behavior, and default recovery remains startup `-agentpath`. | **Yes: ship-as-preview-draft.** | `allowAttachSelf=false` warns rather than hard-refusing the external CLI; `cross-user` and `not-a-jvm` failures print `attach failed (reason=…)`; pytest reports 55 passed. Review remains required before capability or default-policy expansion. |
 | **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
 | **#11** | Optional privileged observer at `dc30188118a6579c024978fa9ff52ca154012170`, with a versioned plugin ABI and Linux maps backend. It is default-off userspace code with no kernel files. | **Yes: ship-as-preview-userspace.** | Yes for later promotion and merge-order integration with #7. It is not a kernel feature, and the default remains **no**. |
 | **#12** | Desktop live-attach/listen GUI at `e07275c1dc0500db3afe79b78792835f510c4a35`, based on PR #8. The must-fixes cover clipping, honest Run disabling when the attach CLI is absent, `outcomeFor` tests, the `allowAttachSelf` warning, and manifest-derived `bindingGaps`; visual shots 07–12 are preview-ok. | **Yes: ship-as-preview after #8.** | Yes for integration review after #8. An enabled attach Run also needs the #9 CLI; the GUI does not replace the CLI. |
+| **#13** | Desktop attach wiring at `542046b8b64668d25657fcf61941a1bfc73eb5c8`, based on #12 rather than `main`. It merges #9’s attach CLI and `Agent_OnAttach` into the desktop stack so GUI Run works. Desktop-ui reports 52 passing tests, attach reports 55, and shot `13-attach-ready` is preview evidence. | **Yes: ship-as-preview after #8 and #12.** | Yes for stacked integration and overlap handling. Because #13 contains #9’s attach files, landing both on `main` requires conflict care. |
 
 ## Current evidence and boundaries
 
 ### Generic-first discovery (#4)
 
 - The reviewed revision is
-  `d6d2637a8aee382c409844603a0631f4197d6e1f`.
+  `5d43cd4508118c8f385bbf5606a9d15cd0a2e41d`.
 - Committed x86-64 fixtures exercise real PE, Mach-O, stripped ELF without
   `.symtab`, and exports-only ELF images.
 - Committed fixtures also exercise a real AArch64 ELF and a
   section-header-removed ELF mapped from `PT_LOAD`.
 - Independent review confirmed that the former is a real AArch64 ELF and the
   latter has zero section headers.
+- A real Mach-O arm64 dylib now proves that format and architecture.
 - Pytest covers at least 23 introspection-and-merge cases; the implementer
   reports 31 passing in the full suite.
 - Ambiguous count-only matching is represented with `bindingGaps`; it is not
@@ -58,7 +60,7 @@ review can be skipped.
 - The branch can ship as a draft/development path.
 - The `recover` default is unchanged.
 - It is not the default release path.
-- Mach-O arm64, 32-bit ARM, and encrypted or shuffled tables remain unproven.
+- 32-bit ARM and encrypted or shuffled tables remain unproven.
 
 The consequence is deliberate: developers can continue validating the generic
 path without presenting incomplete platform coverage as a released default.
@@ -75,16 +77,17 @@ carry an explicit module-local toolchain requirement.
 ### Native-x86 preview (#7)
 
 The reviewed preview revision is
-`8b9231c145e80acbc723fbc893d072398cba143b`.
+`1817e2d664b0a72269f188cbc4a9ddc342b62f0a`.
 
-- `bash native-x86/smoke-test.sh` passes sections 1–14.
+- `bash native-x86/smoke-test.sh` passes sections 1–15 on Linux.
 - Observation is metadata-only.
 - Live register metadata is limited to RIP and RSP.
 - Command-line integer parsing is strict.
 - A live-operation error fails the operation and restores the target state.
 - Multi-threaded targets refuse live operation and fall back to read-only
   inspection.
-- Windows live operation is not shipped.
+- Windows provides read-only module/export observation; live breakpoints are not
+  shipped there.
 - No kernel component is shipped.
 - `note.text` is constrained by policy and a 512-byte cap. This is a policy and
   bounded-record decision, not a claim of structural impossibility.
@@ -96,7 +99,7 @@ Merge #7 after the main documentation set and merge #11 last.
 These facts support **ship-as-preview-draft**, not a stable ABI claim or product
 feature claim.
 
-### Optional desktop work (#8 and #12)
+### Optional desktop work (#8, #12, and #13)
 
 - PR #8’s visual pass is complete.
 - PR #8 is an optional artifact viewer and does not replace the CLI.
@@ -108,11 +111,19 @@ feature claim.
   `bindingGaps` from the manifest.
 - PR #12’s visual shots 07–12 are preview-ok.
 - The attach CLI itself is #9; the GUI does not replace the CLI.
+- PR #13 is reviewed at
+  `542046b8b64668d25657fcf61941a1bfc73eb5c8` and remains stacked on PR #12,
+  not `main`.
+- PR #13 merges #9’s attach CLI and `Agent_OnAttach` files into that stack so
+  GUI Run works; desktop-ui reports 52 passing tests and attach reports 55.
+- Shot `13-attach-ready` is the visual preview evidence.
 
-The consequence is that #12 can ship as a preview after #8, and the desktop
-toolchain split must remain explicit rather than silently changing the
-repository baseline. Its attach Run remains disabled until the #9 CLI is
-available.
+The consequence is that #12 can ship as a preview after #8 and #13 can follow
+#12 as a wired preview. The desktop toolchain split must remain explicit rather
+than silently changing the repository baseline. Because #13 already contains
+#9’s attach files, either merge #9 to `main` for the CLI-only path and rebase #13,
+or merge #13 after #12 and treat #9 as included for the desktop stack. Merging
+both branches without that reconciliation should be expected to overlap.
 
 ### JVMTI attach (#9)
 
@@ -127,6 +138,7 @@ available.
 - `allowAttachSelf=false` warns and does not hard-refuse the external CLI.
 - `cross-user` and `not-a-jvm` failures print `attach failed (reason=…)`.
 - The test run reports `pytest`: 55 passed.
+- PR #13 contains these attach files in its #12-based desktop stack.
 
 The consequence is that attach can ship as a preview, but the GUI and CLI must
 display the capability actually obtained and must not imply startup-equivalent
@@ -171,7 +183,7 @@ the recommendation, and the consequence of adopting it.
 - Native-x86 is a **preview draft**, not a product feature.
 - The privileged observer is an **opt-in userspace preview**, not a kernel
   feature; it has no kernel files and is not enabled by default.
-- None of PRs #2–#12 is merged; GitHub currently shows every one as an open
+- None of PRs #2–#13 is merged; GitHub currently shows every one as an open
   draft.
 
 ## Recommended merge order
@@ -181,23 +193,34 @@ the recommendation, and the consequence of adopting it.
 3. **#4** — draft/development generic discovery, explicitly not the default.
 4. **#8** — optional desktop artifact viewer.
 5. **#12** — only after #8, because #12 is based on #8’s branch.
-6. **#9** — opt-in JVMTI attach preview.
-7. **#7** — native-x86 preview, after the main documentation set.
-8. **#11** — last, because of the `docs/privileged-observer.md` overlap with #7.
+6. **#13** — recommended next desktop-stack change; it is based on #12 and
+   already contains #9’s attach CLI and `Agent_OnAttach` files.
+7. **#9** — treat as already included if #13 lands through the desktop stack.
+   If the CLI-only change should land on `main` first, merge #9 before #13 and
+   rebase #13. If both are merged independently, expect overlap and resolve it
+   deliberately.
+8. **#7** — native-x86 preview, after the main documentation set.
+9. **#11** — last, because of the `docs/privileged-observer.md` overlap with #7.
 
 ## Promotion gates
 
 - #4 now has committed x86-64 PE, Mach-O, stripped-ELF-without-`.symtab`, and
   exports-only ELF fixtures, plus real AArch64 ELF and
-  section-header-removed-ELF fixtures. Default promotion remains blocked on
-  Mach-O arm64, 32-bit ARM, and encrypted or shuffled table evidence.
+  section-header-removed-ELF fixtures and a real Mach-O arm64 dylib. Default
+  promotion remains blocked on 32-bit ARM and encrypted or shuffled table
+  evidence.
 - #7 needs explicit plugin trust and transport decisions, additional platform
-  evidence, and a separate promotion review before it can move beyond preview.
+  evidence beyond Linux smoke sections 1–15 and Windows read-only module/export
+  observation, and a separate promotion review before it can move beyond
+  preview. Windows live breakpoints and any kernel path are not present.
 - #8/#12 must keep their JDK 21 requirement module-local unless the repository
   separately approves a baseline migration.
 - #12 is preview-ok at the reviewed revision after its must-fixes, but it still
   depends on #8. An enabled attach Run needs the #9 CLI; without that CLI, Run
   must remain disabled.
+- #13 is preview-ok after #8 and #12, with desktop-ui 52 and attach 55 passing
+  and shot `13-attach-ready`. It carries #9’s attach files, so landing #9 and
+  #13 independently requires a rebase or explicit conflict resolution.
 - #9/#12 must report actual attach capabilities and retain startup `-agentpath`
   as the default recovery path. #9 now warns for `allowAttachSelf=false` rather
   than hard-refusing the external CLI, and prints reason codes for `cross-user`

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -1,6 +1,6 @@
 # Options and status report for JNI-native recovery platform work
 
-> Status checked against GitHub on 2026-08-28. Pull requests #2 through #12 are
+> Status checked against GitHub on 2026-08-29. Pull requests #2 through #12 are
 > all open, unmerged drafts. This report is documentation only; it does not
 > implement or promote a product feature.
 >
@@ -29,7 +29,7 @@ review can be skipped.
 |---:|---|---|---|
 | **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
-| **#4** | Generic-first discovery at `864f1a427c1fa30071733cfe09440cbbe6c6a483`. Committed x86-64 fixtures now cover real PE, Mach-O, stripped ELF without `.symtab`, and exports-only ELF; pytest reports 27 passed. Ambiguous count-only cases still use `bindingGaps`, and `recover` keeps its existing default. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Non-x86-64, section-header-removed ELF, and encrypted or shuffled tables remain unproven. |
+| **#4** | Generic-first discovery at `d6d2637a8aee382c409844603a0631f4197d6e1f`. In addition to the x86-64 formats, committed fixtures now prove real AArch64 ELF and section-header-removed ELF mapped from `PT_LOAD`; independent review confirmed the AArch64 image and zero section headers. Pytest covers at least 23 introspection-and-merge cases, and the implementer reports 31 passing in the full suite. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Mach-O arm64, 32-bit ARM, and encrypted or shuffled tables remain unproven. |
 | **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#6** | `doctor`, setup scripts, launchers, and getting-started material. JDK 17 is retained. | **Yes, as a draft.** | Normal merge review remains; no JDK migration is implied. |
 | **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `8b9231c145e80acbc723fbc893d072398cba143b`, after multiple must-fix rounds. | **Yes, as a preview draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. The current preview verdict is supported by the completed review rounds and smoke evidence. |
@@ -37,24 +37,28 @@ review can be skipped.
 | **#9** | Opt-in JVMTI attach at `f7664e46f89b83bc6ffb6c3680193412c8cbff36`. Common attach refusals are classified, there is no stealth or bypass behavior, and default recovery remains startup `-agentpath`. | **Yes: ship-as-preview-draft.** | `allowAttachSelf=false` warns rather than hard-refusing the external CLI; `cross-user` and `not-a-jvm` failures print `attach failed (reason=…)`; pytest reports 55 passed. Review remains required before capability or default-policy expansion. |
 | **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
 | **#11** | Optional privileged observer at `dc30188118a6579c024978fa9ff52ca154012170`, with a versioned plugin ABI and Linux maps backend. It is default-off userspace code with no kernel files. | **Yes: ship-as-preview-userspace.** | Yes for later promotion and merge-order integration with #7. It is not a kernel feature, and the default remains **no**. |
-| **#12** | Desktop live-attach/listen GUI, based on PR #8’s branch rather than `main`. Visual review is preview-ok. | **Yes, as a preview after #8.** | Yes for integration review after #8 and for the same attach limitations as #9. |
+| **#12** | Desktop live-attach/listen GUI at `e07275c1dc0500db3afe79b78792835f510c4a35`, based on PR #8. The must-fixes cover clipping, honest Run disabling when the attach CLI is absent, `outcomeFor` tests, the `allowAttachSelf` warning, and manifest-derived `bindingGaps`; visual shots 07–12 are preview-ok. | **Yes: ship-as-preview after #8.** | Yes for integration review after #8. An enabled attach Run also needs the #9 CLI; the GUI does not replace the CLI. |
 
 ## Current evidence and boundaries
 
 ### Generic-first discovery (#4)
 
 - The reviewed revision is
-  `864f1a427c1fa30071733cfe09440cbbe6c6a483`.
+  `d6d2637a8aee382c409844603a0631f4197d6e1f`.
 - Committed x86-64 fixtures exercise real PE, Mach-O, stripped ELF without
   `.symtab`, and exports-only ELF images.
-- The independent review run reports `pytest`: 27 passed.
+- Committed fixtures also exercise a real AArch64 ELF and a
+  section-header-removed ELF mapped from `PT_LOAD`.
+- Independent review confirmed that the former is a real AArch64 ELF and the
+  latter has zero section headers.
+- Pytest covers at least 23 introspection-and-merge cases; the implementer
+  reports 31 passing in the full suite.
 - Ambiguous count-only matching is represented with `bindingGaps`; it is not
   silently treated as a complete binding.
 - The branch can ship as a draft/development path.
 - The `recover` default is unchanged.
 - It is not the default release path.
-- Non-x86-64 binaries, ELF images with section headers removed, and encrypted
-  or shuffled tables remain unproven.
+- Mach-O arm64, 32-bit ARM, and encrypted or shuffled tables remain unproven.
 
 The consequence is deliberate: developers can continue validating the generic
 path without presenting incomplete platform coverage as a released default.
@@ -97,11 +101,18 @@ feature claim.
 - PR #8’s visual pass is complete.
 - PR #8 is an optional artifact viewer and does not replace the CLI.
 - Its module requires JDK 21 while the repository baseline remains JDK 17.
-- PR #12 is stacked on PR #8’s branch, not on `main`.
-- PR #12’s visual review is preview-ok.
+- PR #12 is reviewed at
+  `e07275c1dc0500db3afe79b78792835f510c4a35` and remains stacked on PR #8.
+- PR #12 fixed clipping, disables Run honestly when the attach CLI is absent,
+  tests `outcomeFor`, surfaces the `allowAttachSelf` warning, and derives
+  `bindingGaps` from the manifest.
+- PR #12’s visual shots 07–12 are preview-ok.
+- The attach CLI itself is #9; the GUI does not replace the CLI.
 
-The consequence is that #12 must follow #8, and the desktop toolchain split must
-remain explicit rather than silently changing the repository baseline.
+The consequence is that #12 can ship as a preview after #8, and the desktop
+toolchain split must remain explicit rather than silently changing the
+repository baseline. Its attach Run remains disabled until the #9 CLI is
+available.
 
 ### JVMTI attach (#9)
 
@@ -177,13 +188,16 @@ the recommendation, and the consequence of adopting it.
 ## Promotion gates
 
 - #4 now has committed x86-64 PE, Mach-O, stripped-ELF-without-`.symtab`, and
-  exports-only ELF fixtures. Default promotion remains blocked on non-x86-64
-  evidence and more incomplete images, including section-header-removed ELF and
-  encrypted or shuffled tables.
+  exports-only ELF fixtures, plus real AArch64 ELF and
+  section-header-removed-ELF fixtures. Default promotion remains blocked on
+  Mach-O arm64, 32-bit ARM, and encrypted or shuffled table evidence.
 - #7 needs explicit plugin trust and transport decisions, additional platform
   evidence, and a separate promotion review before it can move beyond preview.
 - #8/#12 must keep their JDK 21 requirement module-local unless the repository
   separately approves a baseline migration.
+- #12 is preview-ok at the reviewed revision after its must-fixes, but it still
+  depends on #8. An enabled attach Run needs the #9 CLI; without that CLI, Run
+  must remain disabled.
 - #9/#12 must report actual attach capabilities and retain startup `-agentpath`
   as the default recovery path. #9 now warns for `allowAttachSelf=false` rather
   than hard-refusing the external CLI, and prints reason codes for `cross-user`

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -29,23 +29,23 @@ review can be skipped.
 |---:|---|---|---|
 | **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
-| **#4** | Generic-first discovery at `5d43cd4508118c8f385bbf5606a9d15cd0a2e41d`. In addition to the x86-64 formats, committed fixtures prove real AArch64 ELF, section-header-removed ELF mapped from `PT_LOAD`, and a real Mach-O arm64 dylib. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. 32-bit ARM and encrypted or shuffled tables remain unproven. |
+| **#4** | Generic-first discovery at `ce53942811d2fb9de76b30a535f14601257814ea`. In addition to the x86-64 formats, committed fixtures prove real AArch64 ELF, real ELF32 ARM, section-header-removed ELF mapped from `PT_LOAD`, and a real Mach-O arm64 dylib. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. ABIs without a registered backend and encrypted or shuffled tables remain unproven. |
 | **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
-| **#6** | `doctor`, setup scripts, launchers, and getting-started material. JDK 17 is retained. | **Yes, as a draft.** | Normal merge review remains; no JDK migration is implied. |
+| **#6** | `doctor`, setup scripts, launchers, and getting-started material at `52ddeb3ed97a66316fce8be50d9242a71ce71ca0`. Offline discovery is documented as `parse-jar` + `inspect-binary` + `merge-manifest`, with Ghidra optional; `recover` still defaults to dynamic recovery. JDK 17 is retained. | **Yes: ship-as-draft.** | Normal merge review remains; neither a JDK migration nor an offline `recover` default is implied. |
 | **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `1817e2d664b0a72269f188cbc4a9ddc342b62f0a`. Linux smoke passes sections 1–15. Windows supports read-only module/export observation, with no live breakpoints. No kernel component is shipped. | **Yes: ship-as-preview-draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. |
 | **#8** | Optional Swing + FlatLaf artifact viewer. The visual pass is complete. The desktop module uses JDK 21 while the repository baseline remains JDK 17. | **Yes, as an optional desktop draft.** | Yes, principally for the JDK 21 module boundary and normal merge review. |
 | **#9** | Opt-in JVMTI attach at `f7664e46f89b83bc6ffb6c3680193412c8cbff36`. Common attach refusals are classified, there is no stealth or bypass behavior, and default recovery remains startup `-agentpath`. | **Yes: ship-as-preview-draft.** | `allowAttachSelf=false` warns rather than hard-refusing the external CLI; `cross-user` and `not-a-jvm` failures print `attach failed (reason=…)`; pytest reports 55 passed. Review remains required before capability or default-policy expansion. |
 | **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
 | **#11** | Optional privileged observer at `dc30188118a6579c024978fa9ff52ca154012170`, with a versioned plugin ABI and Linux maps backend. It is default-off userspace code with no kernel files. | **Yes: ship-as-preview-userspace.** | Yes for later promotion and merge-order integration with #7. It is not a kernel feature, and the default remains **no**. |
 | **#12** | Desktop live-attach/listen GUI at `e07275c1dc0500db3afe79b78792835f510c4a35`, based on PR #8. The must-fixes cover clipping, honest Run disabling when the attach CLI is absent, `outcomeFor` tests, the `allowAttachSelf` warning, and manifest-derived `bindingGaps`; visual shots 07–12 are preview-ok. | **Yes: ship-as-preview after #8.** | Yes for integration review after #8. An enabled attach Run also needs the #9 CLI; the GUI does not replace the CLI. |
-| **#13** | Desktop attach wiring at `542046b8b64668d25657fcf61941a1bfc73eb5c8`, based on #12 rather than `main`. It merges #9’s attach CLI and `Agent_OnAttach` into the desktop stack so GUI Run works. Desktop-ui reports 52 passing tests, attach reports 55, and shot `13-attach-ready` is preview evidence. | **Yes: ship-as-preview after #8 and #12.** | Yes for stacked integration and overlap handling. Because #13 contains #9’s attach files, landing both on `main` requires conflict care. |
+| **#13** | Desktop attach wiring at `c73528414b933737f5a6a29c4d05a0a60119be33`, based on #12 rather than `main`. It merges #9’s attach CLI and `Agent_OnAttach` into the desktop stack so GUI Run works. Relative `-o` values and viewer tailing now use the same absolute path. Desktop-ui reports 56 passing tests and attach reports 55. | **Yes: ship-as-preview, after #8 and #12.** | Yes for stacked integration and overlap handling. Because #13 contains #9’s attach files, landing both on `main` requires conflict care. |
 
 ## Current evidence and boundaries
 
 ### Generic-first discovery (#4)
 
 - The reviewed revision is
-  `5d43cd4508118c8f385bbf5606a9d15cd0a2e41d`.
+  `ce53942811d2fb9de76b30a535f14601257814ea`.
 - Committed x86-64 fixtures exercise real PE, Mach-O, stripped ELF without
   `.symtab`, and exports-only ELF images.
 - Committed fixtures also exercise a real AArch64 ELF and a
@@ -53,14 +53,15 @@ review can be skipped.
 - Independent review confirmed that the former is a real AArch64 ELF and the
   latter has zero section headers.
 - A real Mach-O arm64 dylib now proves that format and architecture.
-- Pytest covers at least 23 introspection-and-merge cases; the implementer
-  reports 31 passing in the full suite.
+- A committed real ELF32 ARM fixture and its tests now prove 32-bit ARM ELF
+  discovery through the AAPCS32 backend.
 - Ambiguous count-only matching is represented with `bindingGaps`; it is not
   silently treated as a complete binding.
 - The branch can ship as a draft/development path.
 - The `recover` default is unchanged.
 - It is not the default release path.
-- 32-bit ARM and encrypted or shuffled tables remain unproven.
+- ABIs without a registered backend and encrypted or shuffled tables remain
+  unproven.
 
 The consequence is deliberate: developers can continue validating the generic
 path without presenting incomplete platform coverage as a released default.
@@ -70,9 +71,16 @@ path without presenting incomplete platform coverage as a released default.
 - The branch can ship as a draft.
 - The repository baseline remains JDK 17.
 - Desktop-specific JDK 21 requirements do not move this setup path to JDK 21.
+- The documented offline discovery path is `parse-jar` + `inspect-binary` +
+  `merge-manifest`; those steps produce a method-discovery manifest rather than
+  recovered method bodies.
+- Ghidra is an optional later static-recovery step, not a prerequisite for
+  offline discovery.
+- `recover` continues to default to the dynamic path.
 
 This keeps the baseline stable while allowing the optional desktop module to
-carry an explicit module-local toolchain requirement.
+carry an explicit module-local toolchain requirement. It also makes offline
+discovery visible without changing the established recovery default.
 
 ### Native-x86 preview (#7)
 
@@ -112,10 +120,13 @@ feature claim.
 - PR #12’s visual shots 07–12 are preview-ok.
 - The attach CLI itself is #9; the GUI does not replace the CLI.
 - PR #13 is reviewed at
-  `542046b8b64668d25657fcf61941a1bfc73eb5c8` and remains stacked on PR #12,
+  `c73528414b933737f5a6a29c4d05a0a60119be33` and remains stacked on PR #12,
   not `main`.
 - PR #13 merges #9’s attach CLI and `Agent_OnAttach` files into that stack so
-  GUI Run works; desktop-ui reports 52 passing tests and attach reports 55.
+  GUI Run works.
+- A relative `-o` is resolved before launch so the attach process and the
+  viewer tail use the same absolute path.
+- Desktop-ui reports 56 passing tests and attach reports 55.
 - Shot `13-attach-ready` is the visual preview evidence.
 
 The consequence is that #12 can ship as a preview after #8 and #13 can follow
@@ -123,7 +134,9 @@ The consequence is that #12 can ship as a preview after #8 and #13 can follow
 than silently changing the repository baseline. Because #13 already contains
 #9’s attach files, either merge #9 to `main` for the CLI-only path and rebase #13,
 or merge #13 after #12 and treat #9 as included for the desktop stack. Merging
-both branches without that reconciliation should be expected to overlap.
+both branches without that reconciliation should be expected to overlap. The
+absolute-path fix removes the relative-output launch/tail mismatch; it does not
+change the preview verdict.
 
 ### JVMTI attach (#9)
 
@@ -176,6 +189,10 @@ the recommendation, and the consequence of adopting it.
 ## What is still not true
 
 - The generic path is **not** the default release path.
+- Generic discovery does **not** cover ABIs without a registered backend or
+  encrypted or shuffled tables.
+- Documenting the offline discovery sequence does **not** change `recover`;
+  dynamic recovery remains its default.
 - Live attach is **not** equivalent to startup instrumentation and is often
   bind-only on OpenJDK 21.
 - Live attach does **not** provide stealth or bypass behavior.
@@ -205,10 +222,10 @@ the recommendation, and the consequence of adopting it.
 ## Promotion gates
 
 - #4 now has committed x86-64 PE, Mach-O, stripped-ELF-without-`.symtab`, and
-  exports-only ELF fixtures, plus real AArch64 ELF and
-  section-header-removed-ELF fixtures and a real Mach-O arm64 dylib. Default
-  promotion remains blocked on 32-bit ARM and encrypted or shuffled table
-  evidence.
+  exports-only ELF fixtures, plus real AArch64 ELF, real ELF32 ARM,
+  section-header-removed-ELF, and real Mach-O arm64 fixtures. Default promotion
+  remains blocked on evidence for ABIs without a registered backend and
+  encrypted or shuffled tables.
 - #7 needs explicit plugin trust and transport decisions, additional platform
   evidence beyond Linux smoke sections 1–15 and Windows read-only module/export
   observation, and a separate promotion review before it can move beyond
@@ -218,9 +235,10 @@ the recommendation, and the consequence of adopting it.
 - #12 is preview-ok at the reviewed revision after its must-fixes, but it still
   depends on #8. An enabled attach Run needs the #9 CLI; without that CLI, Run
   must remain disabled.
-- #13 is preview-ok after #8 and #12, with desktop-ui 52 and attach 55 passing
-  and shot `13-attach-ready`. It carries #9’s attach files, so landing #9 and
-  #13 independently requires a rebase or explicit conflict resolution.
+- #13 is preview-ok after #8 and #12, with relative `-o` launch and tailing
+  sharing one absolute path, desktop-ui 56 and attach 55 passing, and shot
+  `13-attach-ready`. It carries #9’s attach files, so landing #9 and #13
+  independently requires a rebase or explicit conflict resolution.
 - #9/#12 must report actual attach capabilities and retain startup `-agentpath`
   as the default recovery path. #9 now warns for `allowAttachSelf=false` rather
   than hard-refusing the external CLI, and prints reason codes for `cross-user`

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -6,8 +6,8 @@
 > those branches landed, how their reviews judged them, what is now true versus
 > what the original documentation claimed, and which decisions still need a
 > human. It is docs-only and is **not a product ship**. Every draft branch was
-> read but left unchanged; this report is the only new file, added on a fresh
-> branch from `main`.
+> read but left unchanged; this report (PR #10) is the only new file, added on a
+> fresh branch from `main`.
 >
 > Terminology is deliberately neutral: JNI-native transpiled JARs, bytecode
 > restoration, JVMTI diagnostics, process inspection, library instrumentation,
@@ -34,16 +34,20 @@
 - **#5 平台计划 + 决策记录 + 交叉核对**（纯文档）：第二份独立计划，区分"本计划可
   自行决定"与"必须人来拍板"的决策（D1–D11 / B1–B11）。可原样合并。
 - **#6 doctor / setup 脚本 / 上手指南**（代码）：新增环境自检、安装脚本、双语上手
-  文档，把"手动 CLI"重新定位为默认用法。评审判定：**可作为草稿合并，但合并前必须
-  修复**（缺 `capstone` 依赖、JDK17→21 越级、doctor 误报就绪/把告警当阻断等 7 项）。
+  文档，把"手动 CLI"重新定位为默认用法。评审判定：原 7 项必修项已解决，**现处于最后
+  收尾细节阶段**（README 仍残留 `python -m` 示例、ARM 上 doctor 不得把 ARM 标记的
+  遗留 agent 判为 OK、README 引言仍过度宣称"真实字节码方法体"）。
 - **#7 native-x86 隔离 + 插件 ABI**（文档 + 骨架）：独立的用户态观测骨架 + 版本化
   C 插件 ABI，公共头**不含任何 Java/JNI 类型**，且**尚未实现任何观测**。评审判定：
-  **必须修复**（次版本协商会越界写内存、`process_id` 打错进程、生命周期/传输过度宣称）。
+  经必修 + 复审后，**作为文档 + 实验性骨架落地**；早前的 `process_id` / 次版本协商越界写
+  问题已修复；**ABI v0.1 明确为实验性、非产品功能**。
 - **#8 Swing 桌面查看器**（代码）：只读的 CLI 产物查看器（Swing + FlatLaf），不含任何
-  还原逻辑。视觉评审发现并修复 6 个问题，并删除了一个"附加—暂不可用"的假按钮。测试通过。
+  还原逻辑。视觉评审已完成、发现并修复 6 个问题并删除了一个"附加—暂不可用"的假按钮；
+  测试通过。属于**可选桌面草稿**，与其余模块存在 JDK 17/21 分歧，**非正式 UI 发布**。
 - **#9 可选的 JVMTI 实时附加预览**（代码）：新增 `Agent_OnAttach` 与基于 `jdk.attach`
-  的**同用户**附加 CLI；默认 `recover` 流程不变。评审判定：**仅作为可选预览**，且已修复
-  三个必修项（jcmd 误报成功、能力宣称过高、`--log-all` 空开关）。
+  的**同用户**附加 CLI；默认 `recover` 流程不变。评审判定：经必修 + 复审后，**作为预览
+  草稿落地**；三个必修项（jcmd 误报成功、能力宣称过高、`--log-all` 空开关）已修复；
+  OpenJDK 21 实时附加常常只能拿到 bind 能力，**不作默认 recover**。
 
 **所有 8 个 PR 目前都是 OPEN + 草稿状态**，评审结论以仓库内文档形式存在（GitHub 上无
 正式 review 记录）。
@@ -56,7 +60,7 @@
 - **Ghidra 可选**：原文档把静态路径写成"需要 Ghidra"。#4/#6 在文档与命令层把 Ghidra
   降级为可选方法体插件，并提供无 Ghidra 的发现/桩生成路径；但这尚未合并进 `main`。
 - **使用门槛**：原 README 主张"用编码 agent 驱动、别指望手动跑脚本"。#6 用 doctor + 安装
-  脚本 + 上手指南把手动 CLI 变成默认路径；但存在未修复的必修项，尚未合并。
+  脚本 + 上手指南把手动 CLI 变成默认路径；原 7 项必修项已解决，仅剩最后收尾细节，尚未合并。
 - **GUI**：原仓库只有静态截图，无桌面应用。#8 提供了只读桌面查看器（Swing + FlatLaf）。
 - **附加（attach）**：原实现里"attach"其实是用 `-agentpath` 启动新进程。#9 才提供真正的
   实时附加预览（同用户 + 显式 `--pid`），但受 JVM 限制，实时附加通常只能拿到
@@ -72,20 +76,20 @@
 | 桌面技术栈 | Swing + FlatLaf | **已**：#8 已按此实现 |
 | 实时附加策略 | 同用户 + 显式 PID 确认；允许更严的企业策略 | **已**：#9 已按此实现为预览 |
 | native-x86 是否留在本仓库 | 留在仓库但保持隔离（可后续再拆分） | **部分**：骨架已在仓库内且已隔离；"留还是拆"仍开放 |
-| 插件信任 / 传输 | 版本化 C ABI，出现两个真实插件后再冻结；进程内先行，跨进程传输另行定义线格式 | **部分**：#7 给出 ABI 设计与骨架，但有内存安全必修项，传输尚未定义 |
+| 插件信任 / 传输 | 版本化 C ABI，出现两个真实插件后再冻结；进程内先行，跨进程传输另行定义线格式 | **部分**：#7 给出 ABI 设计与骨架，早前内存安全必修项经复审已修复；ABI v0.1 仍为实验性、未冻结，跨进程线格式与信任模型仍待定 |
 | 是否要做特权观测者 | **默认否**，仅在测得用户态确有反复无法覆盖的盲区后，作为后期可选项 | **未**（符合推荐）：仅有边界文档，无任何代码 |
 | 敏感缓冲区 / 库观测 | **默认只采集元数据**；如需内容，须单会话、本地、可打码、显式开启、不外传 | **未**（符合推荐）：未实现；native-x86 记录仅为结构性元数据 |
 
 ### (d) 建议合并顺序
 
-先文档（#2、#3、#5、以及本报告）→ 再 doctor/setup（#6，修完必修项后）→
-通用发现（#4，作为草稿/开发合并，未达默认发布）→ 桌面查看器（#8）→
-实时附加（#9，保持可选预览）→ native-x86（#7，修完必修项后仅作开发者预览）。
+先文档（#2、#3、#5、以及本报告 #10）→ 再 doctor/setup（#6，收尾细节完成后）→
+通用发现（#4，作为草稿/开发合并，未达默认发布）→ 桌面查看器（#8，可选草稿）→
+实时附加（#9，保持预览）→ native-x86（#7，作为实验性文档骨架）。
 
 **在各自评审说 OK 之前不得合并/提升**：#4 在未关闭"仅按数量的无名表定位误绑"前不得
-成为默认发布路径；#6 未修完 7 项必修项不得合并；#7 未修好次版本协商越界写与
-`process_id` 打错前不得被当作稳定 ABI；#9 必须保持可选预览、不得提升为默认或宣称完整
-覆盖；未获人决策前不得开工敏感缓冲区/库内容采集与特权观测者。
+成为默认发布路径；#6 未完成最后收尾细节不得合并；#7 的 ABI v0.1 为实验性，未经稳定化
+不得被当作稳定 ABI 或产品功能；#9 必须保持可选预览、不得提升为默认或宣称完整覆盖；
+未获人决策前不得开工敏感缓冲区/库内容采集与特权观测者。
 
 ### 明确不在范围内 / 未做
 
@@ -114,10 +118,10 @@
 | **#3** | `cursor/genericity-audit-966b` | Docs only: inventory of **85 findings** where code assumes a specific variant, compiler, OS/CPU, or decompiler output shape (`docs/genericity-audit.md`). Facts only, no fix. | **Yes — docs-only.** | Factual inventory; nothing is "fixed" by it. Mergeable as a reference for later generality work. |
 | **#4** | `cursor/generic-first-discovery-ca12` | Code: generic method discovery from JNI structure (vtable index 215 via decoded operands, ABI arg registers, `Java_*` exports), Ghidra demoted to an optional method-body plugin, new `static-lite`/`inventory`-style commands, schema additions, tests + a real ELF fixture (`docs/reviews/generic-first-pr.md`, `docs/generic-recovery.md`). | **As a draft / dev merge: yes. As the default release: no.** | Reviewed twice. Both original must-fixes resolved (real-ELF loading test committed; lifter derives profile from the artifact). Full Python suite 21 passed. Residual (not must-fix): unnamed count-only positional mis-binding; PE/Mach-O loading unproven; section-stripped ELF returns a silent empty registry. |
 | **#5** | `cursor/platform-plan-docs-7274` | Docs only: a second, independent platform plan plus ADR-style decision records that split "decisions this plan makes" (D1–D11) from "decisions reserved for a human" (B1–B11), and a cross-check against #2 (`docs/platform-plan.md`, `docs/decisions.md`, `docs/plan-crosscheck.md`). | **Yes — docs-only.** | Endorses #2's diagnosis; differs on sequencing (front-load decision-free value; defer the event-IR/fusion rebuild). Mergeable as documentation. |
-| **#6** | `cursor/cli-doctor-setup-getting-started-b8b1` | Code: read-only `doctor` preflight, `setup.sh`/`setup.ps1`, `j2c` launchers, bilingual getting-started, Ghidra-free tests; both READMEs reframed so manual CLI is the default and assisted adaptation is optional (`docs/reviews/cli-doctor-setup.md`). | **Ship as draft; must-fix before merge.** | Directionally right, but 7 must-fix items: missing `capstone` dependency (doctor can print `Ready` before `recover` fails), unneeded repo-wide JDK 17→21 bump, native-artifact checks that neither prove readiness nor rebuild staleness, warnings treated as blocking, no-argument path exits non-zero, an undocumented Windows `bash` prerequisite, and readiness/output claims that overstate what `doctor` checks. May still be in re-review. |
-| **#7** | `cursor/native-x86-plugin-abi-5384` | Docs + skeleton: a separate user-mode `native-x86/` module (owned-process/module enumeration, PE/ELF inspection, scoped instrumentation — **none implemented yet**), a versioned C plugin ABI whose public header carries **no Java/JNI types**, and a boundary doc for an optional, unimplemented privileged observer (`docs/reviews/native-x86-abi.md`, `docs/plugin-abi.md`, `docs/privileged-observer.md`). | **No — developer preview / design only.** | Must-fix: minor-version negotiation can overwrite host memory; `process_id` is stamped with the host PID instead of the observed process (or zero); lifecycle/transport docs claim guarantees the skeleton does not enforce. Java/JNI isolation, recovery-pipeline isolation, and the Linux smoke build all pass. |
-| **#8** | `cursor/swing-desktop-viewer-7389` | Code: an optional read-only Swing + FlatLaf desktop viewer that launches CLI stages and renders pipeline status, the method table, and JVMTI trace — **no recovery logic, no browser server** (`docs/reviews/desktop-ui-visual.md`, `jvm/desktop-ui/README.md`). | **Yes, optional** — after CLI/event contracts are stable. | Visual review found and fixed 6 issues (clipped detail pane, mid-token command wrap, centered headers, jumping divider, non-reproducible screenshots) and **removed a permanently-disabled "Attach — not available yet" button**. `:desktop-ui:test` passes. Note: the module targets JDK 21 while the rest of `jvm/` targets JDK 17. |
-| **#9** | `cursor/opt-in-jvmti-live-attach-1155` | Code: opt-in live attach preview — export `Agent_OnAttach`, a `jdk.attach` **same-user** CLI (`--i-own-this-process` + required explicit `--pid`), lazy per-thread install, capability/gap/drop records over the existing agent; default `recover` (startup `-agentpath`) unchanged (`docs/reviews/jvm-attach.md`, `docs/jvm-attach.md`). | **No initially — opt-in preview only.** | Three must-fix items resolved: `jcmd` false success on load failure, coverage claims that exceeded what a live attach obtains, and a dead `--log-all` switch. Empirically on OpenJDK 21 a live attach obtains **only** `native-method-bind`; entry/exit/locals/exception are `OnLoad`-only, so records and docs were corrected to say so. Full method-body recovery still needs the startup path. |
+| **#6** | `cursor/cli-doctor-setup-getting-started-b8b1` | Code: read-only `doctor` preflight, `setup.sh`/`setup.ps1`, `j2c` launchers, bilingual getting-started, Ghidra-free tests; both READMEs reframed so manual CLI is the default and assisted adaptation is optional (`docs/reviews/cli-doctor-setup.md`). | **Ship as draft; final nit pass.** | The original 7 must-fix items are resolved. What remains is a **final nit pass**: the README still shows leftover `python -m` examples, `doctor` on ARM must not report an ARM-labelled leftover agent as OK, and the README intro still over-claims "real bytecode bodies." Merge once those nits close. |
+| **#7** | `cursor/native-x86-plugin-abi-5384` | Docs + skeleton: a separate user-mode `native-x86/` module (owned-process/module enumeration, PE/ELF inspection, scoped instrumentation — **none implemented yet**), a versioned C plugin ABI whose public header carries **no Java/JNI types**, and a boundary doc for an optional, unimplemented privileged observer (`docs/reviews/native-x86-abi.md`, `docs/plugin-abi.md`, `docs/privileged-observer.md`). | **Ship as a documentation + experimental skeleton.** | After must-fix + re-review: the earlier must-fixes (minor-version negotiation memory overwrite, `process_id` mislabeling, overclaimed lifecycle/transport) are addressed. **ABI v0.1 is explicitly experimental/unstable and is not a product feature.** Java/JNI isolation, recovery-pipeline isolation, and the Linux smoke build pass. |
+| **#8** | `cursor/swing-desktop-viewer-7389` | Code: an optional read-only Swing + FlatLaf desktop viewer that launches CLI stages and renders pipeline status, the method table, and JVMTI trace — **no recovery logic, no browser server** (`docs/reviews/desktop-ui-visual.md`, `jvm/desktop-ui/README.md`). | **Yes, optional desktop draft** — not a formal UI ship. | Visual pass is **done**: it found and fixed 6 issues (clipped detail pane, mid-token command wrap, centered headers, jumping divider, non-reproducible screenshots) and **removed a permanently-disabled "Attach — not available yet" button**. `:desktop-ui:test` passes. Remaining item is the JDK split — the module targets JDK 21 while the rest of `jvm/` targets JDK 17. This is an optional desktop draft, not a formal UI ship. |
+| **#9** | `cursor/opt-in-jvmti-live-attach-1155` | Code: opt-in live attach preview — export `Agent_OnAttach`, a `jdk.attach` **same-user** CLI (`--i-own-this-process` + required explicit `--pid`), lazy per-thread install, capability/gap/drop records over the existing agent; default `recover` (startup `-agentpath`) unchanged (`docs/reviews/jvm-attach.md`, `docs/jvm-attach.md`). | **Ship as a preview draft** — not default recover. | After must-fix + re-review: the three must-fixes (`jcmd` false success on load failure, coverage claims exceeding what a live attach obtains, and a dead `--log-all` switch) are resolved. Empirically on OpenJDK 21 a live attach is **often bind-only** (`native-method-bind`); entry/exit/locals/exception are `OnLoad`-only, so records and docs were corrected to say so. Full method-body recovery still needs the startup path. |
 
 ---
 
@@ -164,10 +168,11 @@ the **gap** an owner should keep in mind.
   `j2c` launchers, and a bilingual getting-started guide, and reframes both
   READMEs so **manual CLI use is the default** and assisted adaptation is
   optional.
-- **Gap.** Not merged, and its own review lists 7 must-fix items — most notably
-  that `doctor` can approve an unusable install (missing `capstone`) and reject a
-  usable one (warnings treated as blocking). The barrier is lowered on the branch
-  but not yet reliably.
+- **Gap.** Not merged. Its original 7 must-fix items are resolved; a **final nit
+  pass** remains (leftover `python -m` examples in the README, `doctor` on ARM not
+  OK-ing an ARM-labelled leftover agent, and a README intro that still over-claims
+  "real bytecode bodies"). The barrier is lowered on the branch and close to
+  merge-ready.
 
 ### 2.4 GUI
 
@@ -204,9 +209,10 @@ the **gap** an owner should keep in mind.
   keeps the recovery pipeline (`py/`, `jvm/`, `native/`, `ghidra/`) untouched. A
   future JVM adapter is documented as living *outside* this directory.
 - **Gap.** It is a **skeleton plus documentation** — no process observation or
-  instrumentation is implemented — and it has memory-safety and labeling must-fix
-  items (see §3.5). Some design docs overclaim ABI stability, lifecycle gating,
-  and out-of-process transport relative to what the skeleton enforces.
+  instrumentation is implemented. After re-review the earlier memory-safety and
+  labeling must-fix items are resolved (see §3.5); **ABI v0.1 remains explicitly
+  experimental and is not a product feature**, and the out-of-process transport /
+  wire schema is still future work rather than a property the skeleton enforces.
 
 ---
 
@@ -302,14 +308,13 @@ long-term maintenance.
   transport**. Decide trust explicitly rather than defaulting to in-process trust.
 - **Consequences.** A stable, long-lived extension point, but ABI compatibility
   becomes a maintenance obligation, so the freeze is deliberately evidence-gated.
-- **Work already proceeded?** **Partially, and it is not yet safe to rely on.** #7
-  publishes the C ABI design and a working skeleton, but the review found the
-  minor-version negotiation can **overwrite host memory** (both sides currently
-  reject `struct_size` mismatches instead of reading only the common prefix), the
-  event copy is shallow with process-local pointers (so "drop-in" out-of-process
-  transport is overclaimed), and the lifecycle "events only between start/stop" is
-  not enforced. These must be fixed before the ABI is treated as a versioned
-  extension mechanism. The trust model is explicitly left to a human.
+- **Work already proceeded?** **Partially.** #7 publishes the C ABI design and a
+  working skeleton, and after re-review the earlier defects (minor-version
+  negotiation memory overwrite, `process_id` mislabeling, and overclaimed
+  lifecycle/transport) are addressed. **ABI v0.1 is explicitly experimental — not
+  frozen, and not a product feature.** A real out-of-process wire schema and the
+  trust model (in-process trust versus isolation) remain open and are left to a
+  human; the freeze still waits for two real plugins.
 
 ### 3.6 Whether a privileged observer should ever be built
 
@@ -370,20 +375,23 @@ The order deliberately establishes **truthful docs and lowered setup friction
 before** adding more front ends or observers. Docs branches are mergeable now
 (owner sign-off aside); code branches merge only after their review gates clear.
 
-1. **Docs first — #2, #3, #5 (+ this report).** Docs-only; they change no runtime
-   behavior and set the contracts and honest labels everything else references.
-   Merge in any order among themselves.
-2. **#6 — doctor / setup / getting-started.** After its **7 must-fix items** are
-   resolved. It removes the largest usage barrier and is a prerequisite for a
-   good first-run experience.
+1. **Docs first — #2, #3, #5 (+ this report, #10).** Docs-only; they change no
+   runtime behavior and set the contracts and honest labels everything else
+   references. Merge in any order among themselves.
+2. **#6 — doctor / setup / getting-started.** After its **final nit pass** closes
+   (leftover `python -m` examples, ARM `doctor` not OK-ing an ARM-labelled leftover
+   agent, the "real bytecode bodies" README over-claim). It removes the largest
+   usage barrier and is a prerequisite for a good first-run experience.
 3. **#4 — generic-first discovery.** As a **draft / development merge**, not as
    the default release path. It proves the generic front door (ELF verified).
-4. **#8 — Swing desktop viewer.** After the CLI/event contracts it consumes are
-   stable; visual fixes are already applied.
-5. **#9 — live attach.** Kept an **opt-in preview**; the default `recover` path
-   stays on startup `-agentpath`.
-6. **#7 — native-x86 core + plugin ABI.** After its **must-fix items** are fixed,
-   and only as a **developer preview**.
+4. **#8 — Swing desktop viewer.** An **optional desktop draft** (not a formal UI
+   ship), after the CLI/event contracts it consumes are stable; visual fixes are
+   already applied.
+5. **#9 — live attach.** Kept a **preview draft**; the default `recover` path stays
+   on startup `-agentpath`.
+6. **#7 — native-x86 core + plugin ABI.** As a **documentation + experimental
+   skeleton** after its must-fix + re-review — ABI v0.1 is experimental and not a
+   product feature.
 
 ### What must not be merged / promoted until its review says so
 
@@ -391,14 +399,15 @@ before** adding more front ends or observers. Docs branches are mergeable now
   positional mis-binding** is closed (it silently binds a stack table to the first
   class with a matching native-method count); PE (`.dll`) and Mach-O loading paths
   should also be proven by committed fixtures.
-- **#6 must not merge** until the missing `capstone` dependency, the unnecessary
-  repo-wide JDK 17→21 bump, the native-artifact readiness/idempotence checks, the
-  warnings-as-blocking bug, the non-zero no-argument exit, the undocumented Windows
-  `bash` prerequisite, and the overstated readiness/output claims are addressed.
-- **#7 must not be treated as a stable ABI or shipped beyond a developer preview**
-  until the minor-version negotiation memory-overwrite and the `process_id`
-  mislabeling are fixed and the lifecycle/transport docs are narrowed to what is
-  enforced.
+- **#6 must not merge** until its final nit pass closes: the leftover `python -m`
+  examples in the README, `doctor` on ARM reporting an ARM-labelled leftover agent
+  as OK, and the README intro that still over-claims "real bytecode bodies." (The
+  original 7 must-fix items are already resolved.)
+- **#7's ABI v0.1 is experimental and must not be treated as a stable ABI or a
+  product feature.** The earlier defects (minor-version negotiation memory
+  overwrite, `process_id` mislabeling, overclaimed lifecycle/transport) are fixed;
+  it ships as a documentation + experimental skeleton, and a real out-of-process
+  wire schema plus the freeze (after two real plugins) remain future work.
 - **#9 must stay an opt-in preview**; it must not be promoted to the default
   `recover` path and must not claim entry/exit/locals/exception coverage unless the
   per-capability record reports it available.

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -29,7 +29,7 @@ review can be skipped.
 |---:|---|---|---|
 | **#2** | Design-theory assessment and PR sequence; documentation only and mergeable as documentation. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#3** | Genericity audit; documentation only. | **Yes, as docs.** | Owner factual spot-check only. |
-| **#4** | Generic-first discovery at `ce53942811d2fb9de76b30a535f14601257814ea`. In addition to the x86-64 formats, committed fixtures prove real AArch64 ELF, real ELF32 ARM, section-header-removed ELF mapped from `PT_LOAD`, and a real Mach-O arm64 dylib. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. ABIs without a registered backend and encrypted or shuffled tables remain unproven. |
+| **#4** | Generic-first discovery at `30775d85a0bfb0c8a553c1d3aa5019d4ec38b0a1`. In addition to the earlier format and architecture fixtures, committed fixtures now prove a shared-dispatch second registration family that recovers two tables from one `RegisterNatives` site, plus a genuine i386 ELF through the System V cdecl backend. | **Yes: ship-as-draft-dev; not as the default release.** | Yes before default promotion. Architectures without a registered ABI backend and encrypted or shuffled tables remain unproven. |
 | **#5** | Platform plan selecting Swing + FlatLaf and recording reserved decisions; documentation only. | **Yes, as docs.** | Owner documentation sign-off only. |
 | **#6** | `doctor`, setup scripts, launchers, and getting-started material at `52ddeb3ed97a66316fce8be50d9242a71ce71ca0`. Offline discovery is documented as `parse-jar` + `inspect-binary` + `merge-manifest`, with Ghidra optional; `recover` still defaults to dynamic recovery. JDK 17 is retained. | **Yes: ship-as-draft.** | Normal merge review remains; neither a JDK migration nor an offline `recover` default is implied. |
 | **#7** | Native-x86 process inspection, library instrumentation, and plugin ABI at `1817e2d664b0a72269f188cbc4a9ddc342b62f0a`. Linux smoke passes sections 1–15. Windows supports read-only module/export observation, with no live breakpoints. No kernel component is shipped. | **Yes: ship-as-preview-draft only.** | Yes for later promotion, broader platform support, ABI trust, and transport decisions. |
@@ -38,14 +38,14 @@ review can be skipped.
 | **#10** | This options and status report; documentation only. | **Yes, as docs.** | Owner accuracy and decision sign-off. |
 | **#11** | Optional privileged observer at `dc30188118a6579c024978fa9ff52ca154012170`, with a versioned plugin ABI and Linux maps backend. It is default-off userspace code with no kernel files. | **Yes: ship-as-preview-userspace.** | Yes for later promotion and merge-order integration with #7. It is not a kernel feature, and the default remains **no**. |
 | **#12** | Desktop live-attach/listen GUI at `e07275c1dc0500db3afe79b78792835f510c4a35`, based on PR #8. The must-fixes cover clipping, honest Run disabling when the attach CLI is absent, `outcomeFor` tests, the `allowAttachSelf` warning, and manifest-derived `bindingGaps`; visual shots 07–12 are preview-ok. | **Yes: ship-as-preview after #8.** | Yes for integration review after #8. An enabled attach Run also needs the #9 CLI; the GUI does not replace the CLI. |
-| **#13** | Desktop attach wiring at `c73528414b933737f5a6a29c4d05a0a60119be33`, based on #12 rather than `main`. It merges #9’s attach CLI and `Agent_OnAttach` into the desktop stack so GUI Run works. Relative `-o` values and viewer tailing now use the same absolute path. Desktop-ui reports 56 passing tests and attach reports 55. | **Yes: ship-as-preview, after #8 and #12.** | Yes for stacked integration and overlap handling. Because #13 contains #9’s attach files, landing both on `main` requires conflict care. |
+| **#13** | Desktop attach wiring at `52f21efa8e3676cf314edda102c2b3b5cb4bca0f`, based on #12 rather than `main`. It merges #9’s attach CLI and `Agent_OnAttach` into the desktop stack so GUI Run works. Relative `-o` values and viewer tailing use the same absolute path, and remaining-stub guidance now leads with `dynamic-trace`/`recover` while keeping Ghidra as a last resort. | **Yes: ship-as-preview, after #8 and #12.** | Yes for stacked integration and overlap handling. Because #13 contains #9’s attach files, landing both on `main` requires conflict care. |
 
 ## Current evidence and boundaries
 
 ### Generic-first discovery (#4)
 
 - The reviewed revision is
-  `ce53942811d2fb9de76b30a535f14601257814ea`.
+  `30775d85a0bfb0c8a553c1d3aa5019d4ec38b0a1`.
 - Committed x86-64 fixtures exercise real PE, Mach-O, stripped ELF without
   `.symtab`, and exports-only ELF images.
 - Committed fixtures also exercise a real AArch64 ELF and a
@@ -55,13 +55,19 @@ review can be skipped.
 - A real Mach-O arm64 dylib now proves that format and architecture.
 - A committed real ELF32 ARM fixture and its tests now prove 32-bit ARM ELF
   discovery through the AAPCS32 backend.
+- A shared `initClass()`-style dispatcher proves a second registration family:
+  two independently sized tables are recovered from branches reaching one
+  `RegisterNatives` site instead of being collapsed into one silent binding.
+- A genuine i386 ELF fixture proves 32-bit x86 discovery through the System V
+  cdecl backend, including stack arguments and GOT-relative table addressing.
 - Ambiguous count-only matching is represented with `bindingGaps`; it is not
-  silently treated as a complete binding.
-- The branch can ship as a draft/development path.
+  silently treated as a complete binding, including for each shared-dispatch
+  branch.
+- The branch can **ship-as-draft-dev**.
 - The `recover` default is unchanged.
 - It is not the default release path.
-- ABIs without a registered backend and encrypted or shuffled tables remain
-  unproven.
+- Architectures without a registered ABI backend, including 32-bit Windows
+  x86, and encrypted or shuffled tables remain unproven.
 
 The consequence is deliberate: developers can continue validating the generic
 path without presenting incomplete platform coverage as a released default.
@@ -120,23 +126,27 @@ feature claim.
 - PR #12’s visual shots 07–12 are preview-ok.
 - The attach CLI itself is #9; the GUI does not replace the CLI.
 - PR #13 is reviewed at
-  `c73528414b933737f5a6a29c4d05a0a60119be33` and remains stacked on PR #12,
+  `52f21efa8e3676cf314edda102c2b3b5cb4bca0f` and remains stacked on PR #12,
   not `main`.
 - PR #13 merges #9’s attach CLI and `Agent_OnAttach` files into that stack so
   GUI Run works.
 - A relative `-o` is resolved before launch so the attach process and the
   viewer tail use the same absolute path.
-- Desktop-ui reports 56 passing tests and attach reports 55.
 - Shot `13-attach-ready` is the visual preview evidence.
+- When methods remain as stubs, the next-step copy leads with capturing more of
+  the run through `dynamic-trace`, startup `-agentpath`, or one-shot `recover`.
+  It presents a Ghidra `static-reverse` lift only as an optional last resort,
+  and a test asserts that ordering.
 
-The consequence is that #12 can ship as a preview after #8 and #13 can follow
-#12 as a wired preview. The desktop toolchain split must remain explicit rather
-than silently changing the repository baseline. Because #13 already contains
-#9’s attach files, either merge #9 to `main` for the CLI-only path and rebase #13,
-or merge #13 after #12 and treat #9 as included for the desktop stack. Merging
-both branches without that reconciliation should be expected to overlap. The
-absolute-path fix removes the relative-output launch/tail mismatch; it does not
-change the preview verdict.
+The consequence is that #12 can ship as a preview after #8 and #13 can
+**ship-as-preview** after #12. The desktop toolchain split must remain explicit
+rather than silently changing the repository baseline. Because #13 already
+contains #9’s attach files, either merge #9 to `main` for the CLI-only path and
+rebase #13, or merge #13 after #12 and treat #9 as included for the desktop
+stack. Merging both branches without that reconciliation should be expected to
+overlap. The absolute-path fix removes the relative-output launch/tail mismatch,
+and the revised stub guidance puts higher-fidelity run capture ahead of static
+lifting; neither changes the preview verdict.
 
 ### JVMTI attach (#9)
 
@@ -189,8 +199,8 @@ the recommendation, and the consequence of adopting it.
 ## What is still not true
 
 - The generic path is **not** the default release path.
-- Generic discovery does **not** cover ABIs without a registered backend or
-  encrypted or shuffled tables.
+- Generic discovery does **not** cover architectures without a registered ABI
+  backend or encrypted or shuffled tables.
 - Documenting the offline discovery sequence does **not** change `recover`;
   dynamic recovery remains its default.
 - Live attach is **not** equivalent to startup instrumentation and is often
@@ -222,10 +232,11 @@ the recommendation, and the consequence of adopting it.
 ## Promotion gates
 
 - #4 now has committed x86-64 PE, Mach-O, stripped-ELF-without-`.symtab`, and
-  exports-only ELF fixtures, plus real AArch64 ELF, real ELF32 ARM,
-  section-header-removed-ELF, and real Mach-O arm64 fixtures. Default promotion
-  remains blocked on evidence for ABIs without a registered backend and
-  encrypted or shuffled tables.
+  exports-only ELF fixtures, plus real AArch64 ELF, real ELF32 ARM, genuine
+  i386 ELF, section-header-removed ELF, and real Mach-O arm64 fixtures. Its
+  shared-dispatch fixture recovers two tables from one `RegisterNatives` site.
+  Default promotion remains blocked on evidence for architectures without a
+  registered ABI backend and encrypted or shuffled tables.
 - #7 needs explicit plugin trust and transport decisions, additional platform
   evidence beyond Linux smoke sections 1–15 and Windows read-only module/export
   observation, and a separate promotion review before it can move beyond
@@ -236,9 +247,10 @@ the recommendation, and the consequence of adopting it.
   depends on #8. An enabled attach Run needs the #9 CLI; without that CLI, Run
   must remain disabled.
 - #13 is preview-ok after #8 and #12, with relative `-o` launch and tailing
-  sharing one absolute path, desktop-ui 56 and attach 55 passing, and shot
-  `13-attach-ready`. It carries #9’s attach files, so landing #9 and #13
-  independently requires a rebase or explicit conflict resolution.
+  sharing one absolute path and shot `13-attach-ready`. Remaining-stub guidance
+  leads with `dynamic-trace`, startup `-agentpath`, or one-shot `recover`, with
+  Ghidra `static-reverse` last. It carries #9’s attach files, so landing #9 and
+  #13 independently requires a rebase or explicit conflict resolution.
 - #9/#12 must report actual attach capabilities and retain startup `-agentpath`
   as the default recovery path. #9 now warns for `allowAttachSelf=false` rather
   than hard-refusing the external CLI, and prints reason codes for `cross-user`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把 #2–#13 的规划、实现和审查收成一份给人拍板的状态报告。文档-only（`a75b19c`）。本次刷新 #4 在 `7643877` 的独立复审证据：真实 PE 上命名 `j2cc` 探测器触发，CLI 打印 `profile` / `bindingGaps`。

## (a) 本次改动范围
- 仅 `docs/options-and-status.md`。无运行时代码、CLI 默认值、脚本或测试改动。
- #4 行与 “Generic-first discovery” 小节更新到 `7643877759f2354b864908ae4c47a9a76764cfc8`：真实 PE fixture `jni_dispatch_j2cc.dll`（MZ、LIEF PE、machine `0x8664`）；`analysis.profile == "j2cc"`；Microsoft x64 `shared_dispatch` 从 `0x1800010ef` 恢复两张栈表（nMethods 2 和 3）；ELF `libjni_dispatch_shared.so` 仍单独证明 generic `auto`；`inspect-binary` / `merge-manifest` 的 stderr 打印；pytest 31 / 5 / 3；`recover` 相对 main 无行为差异。
- “What is still not true” 与 promotion gates 同步：加密/打乱表与未注册 ABI 仍未证明；`bindingGaps` 不写入 `binary.json`。
- 合并顺序与人工决策表未改。

## (b) 是否可直接上线
可以合入文档。不改变产品行为。#4 仍是 **ship-as-draft-dev，不是默认发布**。

## (c) 上线前是否需要 review
需要维护者读决策表并拍板。无需代码评审。

## (d) review 的前置条件
- #4 head 仍为 `7643877`，PE fixture 与 `j2cc` 结论一致。
- PE `j2cc` 与 ELF `generic` 在报告中保持为两条独立证据。
- `recover` 默认未变；无内核路径。

建议合入顺序：#2/#3/#5/#10 → #6 → #4 → #8 → #12 → #13 → #9 → #7 → #11。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-459becce-9c8e-4f8a-87ec-4640ea985e25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459becce-9c8e-4f8a-87ec-4640ea985e25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

