### PR TITLE
docs: current architecture and feature catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ and its derivatives (e.g. j2cc) — anything that transpiles JVM bytecode
 to C++ then re-invokes Java through the JNI from a packaged
 `.dll` / `.so`.
 
-Three complementary recovery paths:
+Four complementary recovery paths (only **Dynamic** is the default
+`recover` flow):
 
 | Path | Input | Approach |
 |---|---|---|
-| **Dynamic** | obfuscated jar + a runnable command | Attach a JVMTI agent, observe the JNI call stream, lift it back to JVM bytecode |
+| **Dynamic** | obfuscated jar + a runnable command | Load a JVMTI agent at startup, observe the JNI call stream, lift it back to JVM bytecode |
 | **Static-lite** | transpiled jar + native blob | Discover JNI method tables, build a manifest, and emit restoration stubs without Ghidra |
 | **Static body** | offline manifest + optional Ghidra | After discovery, optionally decompile each function and lift pseudo-C to JVM bytecode |
 | **Emulation** | obfuscated blob (no run, no Ghidra) | Run the native code under a CPU emulator + mock JNI; recover the method table, dump decrypted constants, and call methods as pure-function oracles |
@@ -38,6 +39,39 @@ The [optional observer contract](docs/privileged-observer.md) is off by
 default and unsigned by this project. It is not required for JAR recovery; no
 kernel image or kernel source is shipped.
 
+Current architecture, every surface, and default-vs-preview status:
+**[docs/overview.md](docs/overview.md)**
+([中文](docs/overview.zh-CN.md)).
+
+---
+
+## Architecture at a glance
+
+```
+  CLI (scripts/j2c)  ·  optional desktop viewer (scripts/gui.sh)
+                         │  versioned JSON (schemas/)
+          Discovery ─────┼───── Recovery engines ───── Rebuild
+   parse-jar / inspect-  │   dynamic JVMTI (default)    class-rebuilder
+   binary / merge-       │   attach (preview)           → out.jar
+   manifest              │   static-lite (draft-dev)
+                         │   emulate / Ghidra body (optional)
+
+  Adjacent, not on the JAR path:
+    native-x86/                 user-mode metadata observation
+    privileged-observer/        userspace maps; default off
+```
+
+| Surface | Role | Default? |
+|---|---|---|
+| `scripts/j2c recover` | Startup `-agentpath` dynamic recovery | **Yes** |
+| `parse-jar` / `inspect-binary` / `merge-manifest` / `static-lite` | Ghidra-free method discovery + stubs | No (draft-dev) |
+| `emulate` | Unicorn + mock JNI (table / strings / oracle) | No |
+| Ghidra + `static-reverse` | Optional pseudo-C method bodies | No |
+| `scripts/j2c attach` | Live same-user JVMTI attach | No (preview) |
+| `scripts/gui.sh` | Swing + FlatLaf artifact / attach viewer | No (optional) |
+| `native-x86/` | Process-image metadata, plugin ABI 0.2 | No (preview; not on the JAR path) |
+| `privileged-observer/` | Userspace `/proc` maps | No (default **off**) |
+
 ---
 
 ## Run it yourself
@@ -56,9 +90,10 @@ scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 > `python3 -m j2c_dumper_cli` on the *system* interpreter would not find the
 > packages. The launcher picks the interpreter that actually has them.
 
-See [Quick start](#quick-start) below and the
+See [Quick start](#quick-start) below, the
 [10-minute getting-started guide](docs/getting-started.md)
-([中文](docs/getting-started.zh-CN.md)).
+([中文](docs/getting-started.zh-CN.md)), and the
+[architecture overview](docs/overview.md).
 
 **When the auto-output needs a human pass.** This project is a *universal*
 approach for the whole "transpile Java → C/C++ and call back via JNI"
@@ -170,6 +205,15 @@ fine on its own.
   index 171, `RegisterNatives` = 215, `ExceptionCheck` = 228, …), so the
   same engine generalizes across the family. Backends: x86-64 PE/Win64
   and ELF/System-V. See [`docs/emulation-recovery.md`](docs/emulation-recovery.md).
+
+### Optional desktop viewer
+
+- **Swing + FlatLaf** (`jvm/desktop-ui/`, **JDK 21** only for this
+  module). `scripts/gui.sh [session-dir]` opens a session folder and
+  shows methods, recovered bodies, pipeline status, binding gaps, and
+  a live `trace.jsonl` tail. **Attach / Listen** is a front end to
+  `scripts/j2c attach`; it does not invent a second protocol. Recovery
+  steps stay in the CLI. See [docs/desktop-gui.md](docs/desktop-gui.md).
 
 ### Shared
 
@@ -394,6 +438,19 @@ obtained. For full method-body recovery use the startup path. Live attach
 requires an explicit `--pid` and the `--i-own-this-process` confirmation, and
 refuses cross-user targets. Full details: [`docs/jvm-attach.md`](docs/jvm-attach.md).
 
+### Optional desktop viewer
+
+The Swing viewer is **not** required for recovery. After a `recover`
+`--workdir` run (or any session folder with the JSON artifacts):
+
+```bash
+scripts/gui.sh ./work          # Windows: scripts\gui.ps1 .\work
+```
+
+It shows methods, recovered bodies, pipeline status, and can run or
+listen to `attach`. The module needs **JDK 21**; the rest of the
+repository stays on JDK 17. See [`docs/desktop-gui.md`](docs/desktop-gui.md).
+
 ### Offline discovery and static-lite (no live run, no Ghidra)
 
 Start here when the JAR cannot run. These generic discovery stages inspect
@@ -410,7 +467,10 @@ scripts/j2c static-lite in.jar --lib natives.bin --profile generic -o static-lit
 ```
 
 See [`docs/generic-recovery.md`](docs/generic-recovery.md). `inspect-binary`
-prints `profile=`; `merge-manifest` prints `bindingGaps=`.
+prints `format/arch/profile=` and `unreadableTables=` on stderr;
+`merge-manifest` prints `bindingGaps=<n> kinds=…`. `bindingGaps` is not
+written into `binary.json`. A visible-but-unreadable `JNINativeMethod[]`
+becomes an `unreadable-table` gap, not a fabricated binding.
 
 For optional pseudo-C method-body lifting, run Ghidra after static-lite.
 `manifest.json` preserves `analysis.profile` from `binary.json`.
@@ -536,35 +596,54 @@ py/.venv/bin/python -m ast_matcher.cli --list-flags
 
 ---
 
-## Experimental: `native-x86/`
+## Preview: `native-x86/` (not on the JAR path)
 
-[`native-x86/`](native-x86/) is an **experimental skeleton**, separate
-from everything above: a small user-mode plugin ABI for generic x86
-process inspection (modules, symbols, call sites), with no JVM or JNI
-concepts in it. It is **not required for JAR recovery** — the dynamic,
-static and emulation paths ignore it entirely, and the directory can be
-deleted without affecting them.
+[`native-x86/`](native-x86/) is an **experimental / preview** user-mode
+host plus plugins for process-image metadata. It has **no Java types**
+in the public ABI (v0.2). The dynamic, static, and emulation paths do
+not depend on it; the directory can be deleted without affecting them.
 
-Today it ships a versioned C ABI, a host stub that loads a sample
-plugin, and documentation. It implements no instrumentation. See
-[`docs/native-x86-module.md`](docs/native-x86-module.md).
+What it does today:
+
+- Linux: same-user + `--i-own-this-process`; read-only modules/exports,
+  or a **single-thread** live pass (ptrace / INT3) that records
+  metadata-only entry/return of named exports.
+- Windows: read-only module/export snapshot (no live breakpoints).
+- Sample plugins name OpenSSL `SSL_*` / `RSA_*` / `AES_*` / `EVP_*`,
+  JNI-convention `Java_*`, and Windows CNG `BCrypt*` exports.
+
+What it does **not** do: TLS interception, buffer/key/content capture,
+stealth, or any kernel component. See
+[`docs/native-x86-module.md`](docs/native-x86-module.md) and
+[`docs/plugin-abi.md`](docs/plugin-abi.md).
+
+## Preview: privileged observer (userspace, default off)
+
+[`privileged-observer/`](privileged-observer/) is a separate userspace
+plugin host. The shipped Linux backend reads `/proc/<pid>/maps` and
+emits module path/address records. Both
+`--i-enable-privileged-observer` and `--i-own-this-process` are
+required. This repository ships **no kernel image and no kernel
+source**. See [`docs/privileged-observer.md`](docs/privileged-observer.md).
 
 ---
 
 ## Repository layout
 
 ```
-├── jvm/                        Kotlin/ASM modules (Gradle multi-project)
+├── scripts/                    j2c / j2c.ps1, setup, gui.sh / gui.ps1
+├── jvm/                        Kotlin/ASM modules (Gradle; JDK 17 except desktop-ui)
 │   ├── jar-parser/             input.jar  → classes.json
 │   ├── trace-to-bytecode/      manifest + trace.jsonl → recovered/*.json
 │   ├── class-rebuilder/        input.jar + recovered/ → output.jar
-│   └── common/                 shared schema types
-├── native/                     C++ JVMTI agent (zig c++ build)
-├── native-x86/                 experimental user-mode x86 plugin ABI skeleton
+│   ├── common/                 shared schema types
+│   └── desktop-ui/             Swing + FlatLaf viewer (JDK 21)
+├── native/                     C++ JVMTI agent (OnLoad + OnAttach; zig c++)
+├── native-x86/                 preview user-mode observation host + plugins
 │                               (not used by any recovery path)
+├── privileged-observer/        userspace maps host; default off; no kernel image
 ├── ghidra/scripts/             Ghidra headless scripts (Java)
 ├── py/                         Python modules (uv workspace)
-│   ├── jar_parser/             —
 │   ├── binary_introspect/      .dll / .so / natives.bin  → binary.json
 │   │   ├── arch/               per-arch / ABI implementations
 │   │   ├── jni_tables.py       RegisterNatives table discovery
@@ -577,7 +656,7 @@ plugin, and documentation. It implements no instrumentation. See
 │   ├── native_emulate/         emulation path: j2c_emu.py (Unicorn + mock JNI)
 │   └── snippet_importer/       (optional) native-obfuscator cppsnippets ingestor
 ├── .claude/skills/             j2c-deobfuscate skill (agent playbook)
-├── docs/                       ARCHITECTURE.md, ROADMAP.md, profile guide, …
+├── docs/                       overview, ARCHITECTURE, ROADMAP, …
 ├── schemas/                    JSON Schema for every artifact
 └── tests/                      e2e fixtures and pipeline tests
 ```
@@ -586,23 +665,30 @@ plugin, and documentation. It implements no instrumentation. See
 
 ## Documentation
 
+- [overview.md](docs/overview.md) — **start here for architecture and every
+  feature** ([中文](docs/overview.zh-CN.md))
 - [getting-started.md](docs/getting-started.md) — 10-minute default-path
   walkthrough, common failures, where the JSON artifacts land
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — module boundaries, pipeline,
   artifact schemas, extension points
+- [desktop-gui.md](docs/desktop-gui.md) — optional Swing viewer
+  ([module README](jvm/desktop-ui/README.md))
+- [jvm-attach.md](docs/jvm-attach.md) — opt-in live JVMTI attach (preview)
 - [emulation-recovery.md](docs/emulation-recovery.md) — emulation path how-to
   (+ command reference in [`py/native_emulate/README.md`](py/native_emulate/README.md))
 - [generic-recovery.md](docs/generic-recovery.md) — Ghidra-free method discovery,
-  manifests, stubs, and optional emulation
+  manifests, stubs, honest gaps, and optional emulation
 - [manual-restoration.md](docs/manual-restoration.md) — hand-cleaning recovered output
+- [options-and-status.md](docs/options-and-status.md) — decisions, merge status,
+  promotion gates
 - [ROADMAP.md](docs/ROADMAP.md) — known limitations and planned work
 - [adding-obfuscator-profile.md](docs/adding-obfuscator-profile.md) — how
   to register a new obfuscator variant
 - [static-reverse-approach.md](docs/static-reverse-approach.md) — design
   notes for the Ghidra-based path
-- [native-x86-module.md](docs/native-x86-module.md) — experimental
-  user-mode x86 module: boundary and non-goals
-  ([plugin ABI](docs/plugin-abi.md),
+- [native-x86-module.md](docs/native-x86-module.md) — preview user-mode
+  observation ([plugin ABI](docs/plugin-abi.md),
+  [crypto plugins](docs/plugins/crypto-libraries.md),
   [privileged observer](docs/privileged-observer.md))
 - [`.claude/skills/j2c-deobfuscate`](.claude/skills/j2c-deobfuscate/SKILL.md) —
   the agent playbook (load this into your coding agent)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,11 +7,11 @@
 及其衍生工具（如 j2cc）—— 凡是把 JVM 字节码翻成 C++、再通过 JNI 从打包进
 JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 
-提供三条互补的恢复路径：
+提供四条互补的恢复路径（只有**动态**是默认的 `recover` 流程）：
 
 | 路径 | 输入 | 思路 |
 |---|---|---|
-| **动态** | 混淆后的 JAR + 一条可运行的命令 | 加载 JVMTI agent，观察 JNI 调用流，把它重新拼回 JVM 字节码 |
+| **动态** | 混淆后的 JAR + 一条可运行的命令 | 启动时加载 JVMTI agent，观察 JNI 调用流，把它重新拼回 JVM 字节码 |
 | **轻量静态** | 转译后的 JAR + native blob | 无需 Ghidra，发现 JNI 方法表、生成 manifest 和字节码还原 stub |
 | **静态方法体** | 离线 manifest + 可选 Ghidra | 发现之后，可选地反编译各函数并把 pseudo-C 抬升回 JVM 字节码 |
 | **模拟** | 混淆后的 blob（不需运行、不需 Ghidra） | 用 CPU 模拟器 + mock JNI 直接跑 native 代码：恢复方法表、dump 解密后的常量、把方法当纯函数来调用 |
@@ -32,6 +32,39 @@ JAR 的 `.dll` / `.so` 回调 Java 的混淆方案，都在覆盖范围内。
 [可选观察器契约](docs/privileged-observer.md)默认关闭，本项目不为其签名。
 JAR 还原不需要它；仓库不发布内核镜像或内核源码。
 
+当前架构、全部表面、默认 vs 预览状态见
+**[docs/overview.zh-CN.md](docs/overview.zh-CN.md)**
+（[English](docs/overview.md)）。
+
+---
+
+## 架构速览
+
+```
+  CLI（scripts/j2c）  ·  可选桌面查看器（scripts/gui.sh）
+                         │  版本化 JSON（schemas/）
+          发现 ──────────┼───── 恢复引擎 ───── 重建
+   parse-jar / inspect-  │   动态 JVMTI（默认）    class-rebuilder
+   binary / merge-       │   attach（预览）         → out.jar
+   manifest              │   轻量静态（draft-dev）
+                         │   模拟 / Ghidra 方法体（可选）
+
+  相邻、不在 JAR 路径上：
+    native-x86/                 用户态 metadata 观察
+    privileged-observer/        用户态 maps；默认关闭
+```
+
+| 表面 | 作用 | 是否默认？ |
+|---|---|---|
+| `scripts/j2c recover` | 启动期 `-agentpath` 动态恢复 | **是** |
+| `parse-jar` / `inspect-binary` / `merge-manifest` / `static-lite` | 无 Ghidra 的方法发现 + stub | 否（draft-dev） |
+| `emulate` | Unicorn + mock JNI（表 / 字符串 / oracle） | 否 |
+| Ghidra + `static-reverse` | 可选 pseudo-C 方法体 | 否 |
+| `scripts/j2c attach` | 活动、同一用户的 JVMTI 附加 | 否（预览） |
+| `scripts/gui.sh` | Swing + FlatLaf 产物 / 附加查看器 | 否（可选） |
+| `native-x86/` | 进程镜像 metadata，插件 ABI 0.2 | 否（预览；不在 JAR 路径上） |
+| `privileged-observer/` | 用户态 `/proc` maps | 否（默认**关**） |
+
 ---
 
 ## 自己动手运行
@@ -49,9 +82,10 @@ scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 > `uv` 把 Python 工作区装进 `py/.venv`，所以直接用*系统* `python3 -m j2c_dumper_cli`
 > 找不到这些包。该启动器会挑选真正装了这些包的解释器。
 
-详见下方的 [Quick start](#quick-start) 以及
+详见下方的 [Quick start](#quick-start)、
 [10 分钟上手指南](docs/getting-started.zh-CN.md)
-（[English](docs/getting-started.md)）。
+（[English](docs/getting-started.md)），以及
+[架构与功能一览](docs/overview.zh-CN.md)。
 
 **什么时候需要人工过一遍。** 本项目提供的是对整个"把 Java 转译成 C/C++
 再通过 JNI 回调"混淆器家族的**通用思路**，所以难度较大的目标仍可能需要针对
@@ -119,9 +153,12 @@ scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
 
 ### 动态路径
 
-- **JVMTI agent**（`native/`，C++）。通过 `-agentpath:` 加载，订阅
+- **JVMTI agent**（`native/`，C++）。默认通过 `-agentpath:` 在启动时加载；
+  也可作为预览，用 `Agent_OnAttach` 附加到已经在跑、且属于同一用户的 JVM
+  （见 [`docs/jvm-attach.md`](docs/jvm-attach.md)）。启动时订阅
   `NativeMethodBind`、`MethodEntry`、`MethodExit`、`Exception`、
-  `ExceptionCatch` 等 JVMTI 事件。
+  `ExceptionCatch`；活动附加只订阅 JDK 仍授予的事件（在 OpenJDK 21 上常常
+  只有 `NativeMethodBind`）。
 - **JNI 函数表替换**。在 `VMInit` 和每个 `ThreadStart` 时，把
   `JNIEnv->functions` 指针整体换成一份代理表。代理表里约 80 个槽位都被
   重定向到记录调用日志的 wrapper，wrapper 在转发到原函数前把这次调用
@@ -189,6 +226,14 @@ scripts/j2c recover in.jar -o out.jar --run-cmd "java -jar in.jar"
   `RegisterNatives`=215，`ExceptionCheck`=228…），所以同一套引擎对整个家族
   通用。后端：x86-64 PE/Win64 与 ELF/System-V。详见
   [`docs/emulation-recovery.md`](docs/emulation-recovery.md)。
+
+### 可选桌面查看器
+
+- **Swing + FlatLaf**（`jvm/desktop-ui/`，**仅此模块**需要 JDK 21）。
+  `scripts/gui.sh [会话目录]` 打开会话文件夹，展示方法、恢复后的方法体、
+  管线状态、绑定缺口，以及实时 `trace.jsonl`。**Attach / Listen** 是
+  `scripts/j2c attach` 的前端，不会另起一套协议。恢复步骤仍走 CLI。
+  详见 [docs/desktop-gui.md](docs/desktop-gui.md)。
 
 ### 共用部分
 
@@ -325,6 +370,19 @@ JDK 在附加*之后*还允许申请哪些 JVMTI 能力。在不少 JDK 上（**
 进程附加必须显式提供 `--pid` 和 `--i-own-this-process` 确认标志，并且拒绝跨用户
 目标。详见 [`docs/jvm-attach.md`](docs/jvm-attach.md)。
 
+### 可选桌面查看器
+
+恢复**不需要**这个 Swing 查看器。在 `recover --workdir`（或任何含 JSON
+产物的会话目录）之后：
+
+```bash
+scripts/gui.sh ./work          # Windows：scripts\gui.ps1 .\work
+```
+
+它展示方法、恢复后的方法体、管线状态，并能运行或只监听 `attach`。
+该模块需要 **JDK 21**；仓库其余部分仍是 JDK 17。详见
+[`docs/desktop-gui.md`](docs/desktop-gui.md)。
+
 ### 离线发现与轻量静态（无需运行、无需 Ghidra）
 
 当 JAR 无法运行时先从这里开始。下面的通用发现步骤会检查标准 JNI 导出符号和
@@ -340,7 +398,10 @@ scripts/j2c static-lite in.jar --lib natives.bin --profile generic -o static-lit
 ```
 
 详见 [`docs/generic-recovery.md`](docs/generic-recovery.md)。`inspect-binary`
-会打印 `profile=`，`merge-manifest` 会打印 `bindingGaps=`。
+会在 stderr 打印 `format/arch/profile=` 与 `unreadableTables=`；
+`merge-manifest` 会打印 `bindingGaps=<n> kinds=…`。`bindingGaps` 不会写入
+`binary.json`。可见但不可读的 `JNINativeMethod[]` 会记成 `unreadable-table`
+缺口，而不是编造绑定。
 如需可选的 pseudo-C 方法体抬升，可在轻量静态步骤后运行 Ghidra。
 
 ### 模拟恢复（无需 JVM、无需 Ghidra）
@@ -448,33 +509,50 @@ py/.venv/bin/python -m ast_matcher.cli --list-flags
 
 ---
 
-## 实验性模块：`native-x86/`
+## 预览：`native-x86/`（不在 JAR 路径上）
 
-[`native-x86/`](native-x86/) 是一个与上面所有内容都相互独立的**实验性骨架**：
-一套用户态插件 ABI，用于描述通用的 x86 进程信息（模块、符号、调用点），
-内部不包含任何 JVM / JNI 概念。它**不是 JAR 恢复的必需组件** ——
-动态、静态、模拟三条路径都不依赖它，整个目录删掉也不影响它们。
+[`native-x86/`](native-x86/) 是**实验性 / 预览**的用户态 host + 插件，
+用于进程镜像 metadata。公开 ABI（v0.2）**不含 Java 类型**。动态、静态、
+模拟路径都不依赖它；整个目录删掉也不影响它们。
 
-目前它只包含一个带版本号的 C ABI、一个加载示例插件的 host stub 以及文档，
-没有实现任何插桩逻辑。详见
-[`docs/native-x86-module.md`](docs/native-x86-module.md)。
+目前能做的：
+
+- Linux：同一用户 + `--i-own-this-process`；只读模块/导出，或**单线程**
+  活动观察（ptrace / INT3），只记录具名导出的进入/返回 metadata。
+- Windows：只读模块/导出快照（没有活动断点）。
+- 示例插件按名字观察 OpenSSL `SSL_*` / `RSA_*` / `AES_*` / `EVP_*`、
+  JNI 约定的 `Java_*`、以及 Windows CNG `BCrypt*` 导出。
+
+明确不做的事：TLS 拦截、缓冲区/密钥/内容采集、stealth、任何内核组件。
+详见 [`docs/native-x86-module.md`](docs/native-x86-module.md) 与
+[`docs/plugin-abi.md`](docs/plugin-abi.md)。
+
+## 预览：特权观察器（用户态，默认关闭）
+
+[`privileged-observer/`](privileged-observer/) 是另一套用户态插件 host。
+随仓库提供的 Linux 后端读取 `/proc/<pid>/maps`，输出模块路径与地址。
+必须同时给出 `--i-enable-privileged-observer` 与 `--i-own-this-process`。
+本仓库**不发布内核镜像或内核源码**。详见
+[`docs/privileged-observer.md`](docs/privileged-observer.md)。
 
 ---
 
 ## 仓库结构
 
 ```
-├── jvm/                        Kotlin/ASM 模块（Gradle 多项目）
+├── scripts/                    j2c / j2c.ps1、setup、gui.sh / gui.ps1
+├── jvm/                        Kotlin/ASM 模块（Gradle；除 desktop-ui 外为 JDK 17）
 │   ├── jar-parser/             input.jar  → classes.json
 │   ├── trace-to-bytecode/      manifest + trace.jsonl → recovered/*.json
 │   ├── class-rebuilder/        input.jar + recovered/ → output.jar
-│   └── common/                 公共 schema 类型
-├── native/                     C++ JVMTI agent（zig c++ 构建）
-├── native-x86/                 实验性的用户态 x86 插件 ABI 骨架
+│   ├── common/                 公共 schema 类型
+│   └── desktop-ui/             Swing + FlatLaf 查看器（JDK 21）
+├── native/                     C++ JVMTI agent（OnLoad + OnAttach；zig c++）
+├── native-x86/                 预览级用户态观察 host + 插件
 │                               （任何恢复路径都不依赖它）
+├── privileged-observer/        用户态 maps host；默认关闭；无内核镜像
 ├── ghidra/scripts/             Ghidra Headless 脚本（Java）
 ├── py/                         Python 模块（uv workspace）
-│   ├── jar_parser/             —
 │   ├── binary_introspect/      .dll / .so / natives.bin  → binary.json
 │   │   ├── arch/               按架构 / ABI 的实现
 │   │   ├── jni_tables.py       RegisterNatives 表发现
@@ -487,7 +565,7 @@ py/.venv/bin/python -m ast_matcher.cli --list-flags
 │   ├── native_emulate/         模拟路径：j2c_emu.py（Unicorn + mock JNI）
 │   └── snippet_importer/       （可选）native-obfuscator cppsnippets 导入器
 ├── .claude/skills/             j2c-deobfuscate skill（智能体使用手册）
-├── docs/                       ARCHITECTURE.md、ROADMAP.md、profile 指南 …
+├── docs/                       overview、ARCHITECTURE、ROADMAP …
 ├── schemas/                    每种 artifact 的 JSON Schema
 └── tests/                      端到端 fixture 与管线测试
 ```
@@ -496,19 +574,27 @@ py/.venv/bin/python -m ast_matcher.cli --list-flags
 
 ## 文档
 
+- [overview.zh-CN.md](docs/overview.zh-CN.md) — **架构与全部功能从这里开始**
+  （[English](docs/overview.md)）
 - [getting-started.zh-CN.md](docs/getting-started.zh-CN.md) — 10 分钟默认路径
   上手、常见故障、JSON 产物在哪
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) — 模块边界、管线、artifact schema、扩展点
+- [desktop-gui.md](docs/desktop-gui.md) — 可选 Swing 查看器
+  （[模块 README](jvm/desktop-ui/README.md)）
+- [jvm-attach.md](docs/jvm-attach.md) — 可选活动 JVMTI 附加（预览）
 - [emulation-recovery.md](docs/emulation-recovery.md) — 模拟路径使用指南
   （命令参考见 [`py/native_emulate/README.md`](py/native_emulate/README.md)）
 - [generic-recovery.md](docs/generic-recovery.md) — 无 Ghidra 的方法发现、
-  manifest、stub 与可选模拟
+  manifest、stub、诚实缺口与可选模拟
 - [manual-restoration.md](docs/manual-restoration.md) — 手工清理恢复产物
+- [options-and-status.md](docs/options-and-status.md) — 决策、合并状态、晋升门槛
 - [ROADMAP.md](docs/ROADMAP.md) — 已知限制和计划工作
 - [adding-obfuscator-profile.md](docs/adding-obfuscator-profile.md) — 如何注册新混淆器变体
 - [static-reverse-approach.md](docs/static-reverse-approach.md) — 基于 Ghidra 的静态路径设计笔记
-- [native-x86-module.md](docs/native-x86-module.md) — 实验性用户态 x86 模块的边界与非目标
-  （[插件 ABI](docs/plugin-abi.md)、[特权观察器](docs/privileged-observer.md)）
+- [native-x86-module.md](docs/native-x86-module.md) — 预览级用户态观察
+  （[插件 ABI](docs/plugin-abi.md)、
+  [密码学插件](docs/plugins/crypto-libraries.md)、
+  [特权观察器](docs/privileged-observer.md)）
 - [`.claude/skills/j2c-deobfuscate`](.claude/skills/j2c-deobfuscate/SKILL.md) —
   智能体使用手册（加载到你的编码智能体里）
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,13 @@
 # Architecture
 
 How `c2j-native-deobfuscator` is structured, and where to plug things in.
+For the product-level map (every surface, default vs preview), start at
+[overview.md](overview.md).
 
 ## Goals
 
 - Turn a JNI-native-obfuscated jar back into a jar with **real JVM
-  bytecode** in place of every native stub.
+  bytecode** in place of every native stub, when evidence allows.
 - Stay **obfuscator-agnostic** in the core pipeline; concentrate
   variant-specific knowledge in **profiles** and **architecture
   modules** that can be added without touching the main flow.
@@ -14,8 +16,14 @@ How `c2j-native-deobfuscator` is structured, and where to plug things in.
 - Each stage is a **standalone CLI** that consumes / produces a
   well-defined JSON artifact; the top-level orchestrator just chains
   them.
+- Keep optional surfaces (desktop viewer, live attach, native-x86,
+  privileged observer) **out of the default recover path**.
 
 ## Pipeline
+
+Discovery is shared. Recovery engines are alternatives. The desktop
+viewer and attach CLI sit on the artifact / agent boundary; they do
+not invent a second pipeline.
 
 ```
                  ┌────────────────────────────┐
@@ -29,35 +37,38 @@ How `c2j-native-deobfuscator` is structured, and where to plug things in.
                                                                     ▼
                                               ┌──────────────────────────┐
                                               │ manifest-merge           │
+                                              │  + bindingGaps           │
                                               └──────────────────────────┘
                                                             │
                                                             │ manifest.json
-                                ┌───────────────────────────┴───────────────────────────┐
-                                │                                                       │
-                                ▼ Dynamic path                          Static path     ▼
-              ┌────────────────────────────┐                       ┌─────────────────────────────┐
-              │ JVMTI agent (native/)      │                       │ Ghidra headless             │
-              │  hooks RegisterNatives +   │                       │   ExtractRegisterNatives    │
-              │  every key JNI fn          │                       │   DumpFromManifest          │
-              └────────────────────────────┘                       └─────────────────────────────┘
-                          │                                                            │
-                          │ trace.jsonl                                                │ ghidra-dump.json
-                          ▼                                                            ▼
-              ┌────────────────────────────┐                       ┌─────────────────────────────┐
-              │ trace-to-bytecode          │                       │ ast-matcher                 │
-              │  (Kotlin/ASM lifter)       │                       │  (Python tree-sitter + lifter)
-              └────────────────────────────┘                       └─────────────────────────────┘
-                          │                                                            │
-                          └──────────────┬──── recovered/*.json ────────────────┬──────┘
-                                         ▼                                      ▼
-                                ┌──────────────────────────────────────────────────────┐
-                                │ class-rebuilder                                      │
-                                │  replaces native stubs, strips loader + native blob  │
-                                └──────────────────────────────────────────────────────┘
-                                                       │
-                                                       ▼
-                                                    out.jar
+      ┌─────────────────────┬───────────────────┬───────────┴────────────┐
+      ▼ default             ▼ draft-dev         ▼ optional               ▼ optional
+ ┌──────────────┐     ┌──────────────┐    ┌──────────────┐         ┌──────────────┐
+ │ JVMTI agent  │     │ static-lite  │    │ emulate      │         │ Ghidra       │
+ │ -agentpath   │     │ stubs        │    │ unicorn      │         │ DumpFromMan. │
+ │ (or attach)  │     └──────┬───────┘    └──────┬───────┘         └──────┬───────┘
+ └──────┬───────┘            │ recovered stubs   │ oracle / strings       │ ghidra-dump
+        │ trace.jsonl        │                   │                        ▼
+        ▼                    │                   │                 ast-matcher
+ ┌──────┴───────┐            │                   │                        │
+ │trace-to-bc   │            │                   │                        │
+ └──────┬───────┘            │                   │                        │
+        └────────────────────┴───────────────────┴────────────────────────┘
+        │ recovered/*.json
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────┐
+ │ class-rebuilder  — replace stubs, strip loader + native blob → out.jar   │
+ └──────────────────────────────────────────────────────────────────────────┘
+
+ Surfaces (not engines):  scripts/j2c   ·   scripts/gui.sh (desktop-ui)
+ Adjacent (not on this path):  native-x86/   ·   privileged-observer/
 ```
+
+`recover` uses the **dynamic** column (`-agentpath` at startup).
+`attach` loads the same agent into an already-running same-user JVM
+and writes `trace.jsonl`; it does not rebuild a jar by itself.
+`static-lite` stops at stubs. Emulation does not auto-emit bytecode.
+Ghidra is only for optional method-body lift after discovery.
 
 ## Module boundaries
 
@@ -65,13 +76,17 @@ How `c2j-native-deobfuscator` is structured, and where to plug things in.
 |---|---|---|---|---|
 | `jvm/jar-parser` | Kotlin + ASM | input.jar | `classes.json` | Walk classes, find loader, flag obfuscated natives |
 | `py/binary_introspect` | Python + LIEF + capstone | .dll / .so | `binary.json` | Disassembly-driven discovery of native-method tables |
-| `py/manifest_merge` | Python | `classes.json` + `binary.json` | `manifest.json` | Cross-check + bind fn addresses to (class, method, desc) |
-| `native/` | C++ + JVMTI | runnable jar | `trace.jsonl` | Hook RegisterNatives + 80+ JNI fns at runtime |
+| `py/manifest_merge` | Python | `classes.json` + `binary.json` | `manifest.json` | Bind fn addresses; record `bindingGaps` |
+| `native/` | C++ + JVMTI | runnable or attachable JVM | `trace.jsonl` | `Agent_OnLoad` / `Agent_OnAttach`; hook RegisterNatives + 80+ JNI fns when capabilities allow |
 | `jvm/trace-to-bytecode` | Kotlin + ASM | `manifest.json` + `trace.jsonl` | `recovered/*.json` | Translate JNI call sequences back to JVM bytecode |
-| `ghidra/scripts/` | Java (Ghidra API) | native blob + manifest | `ghidra-dump.json` | Decompile each fn-addr to pseudo-C |
+| `ghidra/scripts/` | Java (Ghidra API) | native blob + manifest | `ghidra-dump.json` | Optional: decompile each fn-addr to pseudo-C |
 | `py/ast_matcher` | Python + tree-sitter | `ghidra-dump.json` + manifest | `recovered/*.json` | Lift pseudo-C to JVM bytecode |
 | `jvm/class-rebuilder` | Kotlin + ASM | input.jar + recovered + manifest | output jar | Replace stubs, strip loader |
-| `py/j2c_dumper_cli` | Python + typer | — | — | Top-level orchestrator |
+| `py/native_emulate` | Python + unicorn | native blob | registrations / strings / oracle | Execute under mock JNI; no bytecode emit |
+| `py/j2c_dumper_cli` | Python + typer | — | — | Top-level orchestrator (`scripts/j2c`) |
+| `jvm/desktop-ui` | Kotlin + Swing + FlatLaf | session directory | — | Optional viewer; JDK 21; runs attach only via the CLI |
+| `native-x86/` | C | owned process | metadata records | Preview process inspection; no Java types in the ABI |
+| `privileged-observer/` | C + Python | owned pid + two flags | module-map JSONL | Userspace maps only; default off; no kernel image |
 
 Schemas: `schemas/*.schema.json`.
 
@@ -132,8 +147,10 @@ CLI: `--enable <flag>` / `--disable <flag>` (repeatable),
 JSON Schema documents under `schemas/`:
 
 - `classes.schema.json`    — `jar-parser` output
-- `binary.schema.json`     — `binary-introspect` output
-- `manifest.schema.json`   — `manifest-merge` output
+- `binary.schema.json`     — `binary-introspect` output (`analysis.profile`,
+  `analysis.unreadableTables`)
+- `manifest.schema.json`   — `manifest-merge` output (`bindingGaps` as
+  `ambiguous-count-only-table` or `unreadable-table`)
 - `trace.schema.json`      — JVMTI agent line format
 - `recovered.schema.json`  — per-method recovered bytecode
 
@@ -151,15 +168,26 @@ Each schema is versioned (`schemaVersion: int`).
 4. **Fail soft.** When a single method's recovery is malformed (e.g.
    stack-imbalanced), the class-rebuilder falls back to a stub for
    that method only; the rest of the jar still ships.
+5. **Honest gaps.** Ambiguous or unreadable `RegisterNatives` tables
+   become `bindingGaps` / `unreadableTables`; they are never silent
+   empty successes and never fabricated names.
+6. **Optional surfaces stay optional.** The desktop viewer, live
+   attach, native-x86, and privileged observer must not become
+   prerequisites of `recover`.
 
 ## Runtime requirements
 
 | Component | Minimum |
 |---|---|
-| JDK (for build + runtime) | 21 |
+| JDK (repository baseline: build + recover) | 17 |
+| JDK (`jvm/desktop-ui` only) | 21 |
 | Python | 3.11 |
 | `lief` | any 0.14+ |
 | `capstone` | 5.x |
-| `tree-sitter-c` | any 0.21+ |
-| Ghidra (static path only) | 11.x |
+| `tree-sitter-c` | any 0.21+ (static body path) |
+| Ghidra (optional static body path only) | 11.x |
 | zig (native agent build) | 0.16+ |
+| unicorn (optional emulation) | any current |
+
+The native agent (`native/build.sh`) targets x86-64. On other CPUs setup
+skips it and `doctor` does not report the dynamic path as ready.

--- a/docs/desktop-gui.md
+++ b/docs/desktop-gui.md
@@ -1,0 +1,43 @@
+# Desktop artifact viewer
+
+Optional **Swing + FlatLaf** client for recovery-pipeline artifacts and
+live attach sessions. It is a viewer and an honest front end to the
+`attach` CLI. It does **not** replace `scripts/j2c`, does not invent a
+second attach protocol, and is not on the default recovery path.
+
+There is no Web UI and no browser server.
+
+## Run
+
+```bash
+scripts/gui.sh                     # empty window; open a folder from the toolbar
+scripts/gui.sh /path/to/session    # open a session directory
+```
+
+Windows: `scripts\gui.ps1 C:\path\to\session`.
+
+The module lives at [`jvm/desktop-ui/`](../jvm/desktop-ui/) and targets
+**JDK 21**. The rest of the repository stays on **JDK 17**. Gradle:
+`cd jvm && ./gradlew :desktop-ui:run --args="/path/to/session"`.
+
+A session directory is any folder that holds one or more of
+`classes.json`, `binary.json`, `manifest.json`, `recovered/`,
+`trace.jsonl`.
+
+## What it shows
+
+- Method table and recovery status (`recovered` / `stub` / `missing`)
+- Read-only recovered instruction listing and raw JSON
+- Pipeline status plus the **next CLI command** (shown, not run)
+- Binary analysis strip: format, arch, profile, discovery strategy,
+  `bindingGaps`
+- Live or static `trace.jsonl`, including `capability` / `gap` rows
+- Attach / Listen form: same-user confirmation, `/proc` refusal
+  pre-scan, parsed `attach failed (reason=…)` banners
+
+Full screen-by-screen notes, visual rules, and screenshot list:
+[`jvm/desktop-ui/README.md`](../jvm/desktop-ui/README.md).
+
+Attach policy and coverage limits:
+[jvm-attach.md](jvm-attach.md). Architecture context:
+[overview.md](overview.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,10 @@ The dynamic path works when you can *launch* the obfuscated jar in your
 environment. If you can't run it, jump to
 [When you can't run the jar](#when-you-cant-run-the-jar).
 
+For the full architecture and every optional surface (desktop viewer,
+live attach, native-x86, privileged observer), see
+[overview.md](overview.md).
+
 ---
 
 ## 0. Prerequisites
@@ -101,6 +105,19 @@ and whose loader / native-blob entries are stripped. Dynamic tracing only covers
 the paths your `--run-cmd` actually executed; unobserved methods may keep a stub
 or a partial body, so inspect the output and expect some manual completion on
 hard targets.
+
+### Optional: look at the session in the desktop viewer
+
+If you have **JDK 21** and passed `--workdir ./work`:
+
+```bash
+scripts/gui.sh ./work
+```
+
+The viewer only displays artifacts (and can front the `attach` CLI). It
+does not run `recover`. See [desktop-gui.md](desktop-gui.md). Live
+attach, if you cannot restart the JVM, is documented in
+[jvm-attach.md](jvm-attach.md) (`scripts/j2c attach --pid … --i-own-this-process`).
 
 ---
 

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -8,6 +8,9 @@
 动态路径的前提是你能在自己的环境里**跑起来**这个混淆 jar。如果跑不起来，请直接
 看[目标跑不起来时怎么办](#目标跑不起来时怎么办)。
 
+完整架构与全部可选表面（桌面查看器、活动附加、native-x86、特权观察器）见
+[overview.zh-CN.md](overview.zh-CN.md)。
+
 ---
 
 ## 0. 前置条件
@@ -89,6 +92,19 @@ scripts/j2c recover \
 行为、尽力恢复出的方法体**，loader / native blob 资源条目也被剥离。动态 trace 只
 覆盖 `--run-cmd` 实际执行到的路径；未观察到的方法可能仍是桩或只有部分方法体，因此
 请检查输出，难度较大的目标要预期需要人工补全。
+
+### 可选：用桌面查看器看这次会话
+
+如果你有 **JDK 21**，并且传了 `--workdir ./work`：
+
+```bash
+scripts/gui.sh ./work
+```
+
+查看器只展示产物（也能作为 `attach` CLI 的前端），不会自己跑 `recover`。
+详见 [desktop-gui.md](desktop-gui.md)。如果 JVM 不能重启，活动附加见
+[jvm-attach.md](jvm-attach.md)
+（`scripts/j2c attach --pid … --i-own-this-process`）。
 
 ---
 

--- a/docs/native-x86-module.md
+++ b/docs/native-x86-module.md
@@ -77,8 +77,10 @@ These are boundaries, not a backlog.
 - **No signature or protection bypass.** Nothing here exists to defeat
   licensing, integrity checks or code signing.
 - **No kernel component in this tree.** See
-  [privileged-observer.md](privileged-observer.md): the privileged path
-  is documentation only, and no signed driver is provided.
+  [privileged-observer.md](privileged-observer.md): the in-repo
+  privileged observer is a **userspace** maps plugin (default off).
+  This repository ships no kernel image, kernel source, or signed
+  driver.
 - **No Java coupling.** No JNI header, no Gradle module, no
   `jni.h` include, ever, under `native-x86/`. See
   [`native-x86/bridge-notes.md`](../native-x86/bridge-notes.md).

--- a/docs/options-and-status.md
+++ b/docs/options-and-status.md
@@ -11,6 +11,9 @@
 > Terminology in this report is deliberately neutral: JNI-native transpiled JAR
 > recovery, JVMTI, process inspection, library instrumentation, plugin ABI, and
 > privileged observer.
+>
+> Product-level architecture and the feature catalog:
+> [overview.md](overview.md) ([中文](overview.zh-CN.md)).
 
 ## Executive recommendation
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,259 @@
+# Architecture and features
+
+[English](overview.md) | [中文](overview.zh-CN.md)
+
+This page is the current map of `c2j-native-deobfuscator`: how the pieces
+fit together, what each surface does, and what is **not** a default or
+not shipped. It describes the tree on `main` after the #2–#14 wrap-up.
+It does not change runtime defaults.
+
+Companion pages: [ARCHITECTURE.md](ARCHITECTURE.md) (module contracts),
+[options-and-status.md](options-and-status.md) (decisions and promotion
+gates), [getting-started.md](getting-started.md) (10-minute default path).
+
+Terminology is deliberately neutral: JNI-native transpiled JAR recovery,
+JVMTI, process inspection, library instrumentation, plugin ABI, and
+privileged observer.
+
+---
+
+## What this project is
+
+The core product is a **CLI recovery toolkit** for JARs whose Java
+methods were transpiled to C/C++ and re-entered through JNI (the
+[`native-obfuscator`](https://github.com/radioegor146/native-obfuscator)
+family and derivatives such as j2cc).
+
+`scripts/j2c` is the automation contract. The optional Swing viewer
+shows artifacts; it does not replace the CLI. Adjacent user-mode
+observation modules sit **outside** the JAR pipeline and can be ignored
+or deleted without affecting recovery.
+
+The repository baseline is **JDK 17** and **Python 3.11+**. The desktop
+module alone requires **JDK 21**. The native JVMTI agent builds for
+**x86-64**.
+
+---
+
+## Layered architecture
+
+```
+  ┌──────────────────────────────────────────────────────────────────┐
+  │ Surfaces                                                         │
+  │   CLI  scripts/j2c  (doctor, recover, attach, stages)            │
+  │   Desktop viewer  scripts/gui.sh  (optional, read-mostly)        │
+  └───────────────────────────────┬──────────────────────────────────┘
+                                  │ versioned JSON under schemas/
+  ┌───────────────────────────────┼──────────────────────────────────┐
+  │ Discovery                     │  Recovery engines                │
+  │   jar-parser → classes.json   │   Dynamic JVMTI  (default)       │
+  │   binary-introspect           │   Live attach    (preview)       │
+  │     → binary.json             │   Static-lite stubs (draft-dev)  │
+  │   manifest-merge              │   Emulation      (optional)      │
+  │     → manifest.json           │   Ghidra body    (optional)      │
+  └───────────────────────────────┼──────────────────────────────────┘
+                                  │ recovered/*.json
+                                  ▼
+                     class-rebuilder → out.jar
+
+  Adjacent, not on the JAR path (safe to delete):
+    native-x86/              user-mode metadata observation, plugin ABI 0.2
+    privileged-observer/     userspace /proc maps plugin; default off
+```
+
+Every recovery stage reads and writes **versioned JSON**. Nothing
+crosses a module boundary except through `schemas/`. The orchestrator
+(`py/j2c_dumper_cli`) only chains those stages.
+
+Two adjacent trees produce process-image records, not bytecode:
+
+- [`native-x86/`](../native-x86/) — user-mode host + plugins; no Java
+  types in the public ABI.
+- [`privileged-observer/`](../privileged-observer/) — optional userspace
+  maps backend; **no** kernel image or kernel source.
+
+---
+
+## Recovery pipeline (default and alternatives)
+
+### Default: dynamic `recover`
+
+When the JAR can run, `scripts/j2c recover … --run-cmd "…"` chains:
+
+1. `parse-jar` → `classes.json`
+2. `inspect-binary` → `binary.json` (blob extracted from the JAR)
+3. `merge-manifest` → `manifest.json`
+4. `dynamic-trace` — start the target with `-agentpath` → `trace.jsonl`
+5. `trace-to-bc` → `recovered/*.json`
+6. `rebuild` → loader-stripped `out.jar`
+
+Coverage is **executed branches only**. Unobserved methods may stay
+stubs. This remains the default release path.
+
+### Offline discovery and static-lite (no run, no Ghidra)
+
+`parse-jar` + `inspect-binary` + `merge-manifest` (or one-shot
+`static-lite`) build an auditable method manifest and verifier-safe
+stubs from JNI-spec facts: `Java_*` exports and `RegisterNatives`
+(vtable index 215). This is **draft-dev**, not the default `recover`
+flow, and it does not claim restored method bodies.
+
+Honest gaps are first-class: ambiguous count-only tables become
+`bindingGaps` of kind `ambiguous-count-only-table`; a visible table
+whose name/descriptor bytes are garbage becomes `unreadable-table`
+(not silent skip, not fabricated names). Details:
+[generic-recovery.md](generic-recovery.md).
+
+### Optional static method bodies (Ghidra)
+
+After discovery, Ghidra Headless can decompile each `fnAddr` to
+pseudo-C; `ast_matcher` lifts that to `recovered/*.json`. Ghidra is
+**not** required for discovery.
+
+### Optional emulation
+
+`scripts/j2c emulate` / `py/native_emulate` runs the blob under Unicorn
+plus a mock JNI: list registrations, dump decrypted constants, call a
+method as a pure-function oracle. It does not auto-emit bytecode.
+
+### Live attach (preview)
+
+`scripts/j2c attach --pid <pid> --i-own-this-process` loads the same
+agent into an already-running **same-user** JVM. Startup `-agentpath`
+still sees more. On many JDKs (observed on OpenJDK 21) attach is
+bind-only. There is no stealth or bypass. See
+[jvm-attach.md](jvm-attach.md).
+
+---
+
+## Feature catalog
+
+| Surface | What it does | Status | Default for recovery? |
+|---|---|---|---|
+| `scripts/setup.sh` / `setup.ps1` | Build JVM modules, Python workspace, x86-64 agent | Shipped | Setup only |
+| `scripts/j2c doctor` | Versions + artifacts; next command for gaps | Shipped | Check only |
+| `scripts/j2c recover` | One-shot dynamic recovery | Shipped | **Yes** |
+| Stage CLIs (`parse-jar`, `inspect-binary`, `merge-manifest`, `dynamic-trace`, `trace-to-bc`, `static-reverse`, `rebuild`, `synth-stubs`, `static-lite`, `emulate`) | Isolated JSON stages | Shipped | No (except as `recover` chains them) |
+| Generic JNI discovery | PE/ELF/Mach-O; x86-64, AArch64, ARM, i386 ELF; `j2cc` PE detector; shared-dispatch harvest | Draft-dev | **No** |
+| Honest binding gaps | `bindingGaps` + `analysis.unreadableTables` | Draft-dev | Reporting only |
+| Ghidra `DumpFromManifest` + `ast_matcher` | Optional pseudo-C body lift | Optional plugin | **No** |
+| Emulation (`unicorn`) | Registration / strings / oracle | Optional | **No** |
+| `scripts/j2c attach` | Opt-in live JVMTI attach | Preview | **No** |
+| `scripts/gui.sh` | Swing + FlatLaf artifact / attach viewer | Optional desktop | **No** |
+| `native-x86/` | User-mode metadata observation, ABI 0.2 | Preview | **No** (not on the JAR path) |
+| `privileged-observer/` | Userspace Linux maps plugin | Preview, default **off** | **No** |
+| `.claude/skills/j2c-deobfuscate` | Agent playbook | Optional | Convenience only |
+
+---
+
+## Surfaces in more detail
+
+### CLI
+
+Run everything through `scripts/j2c` (`scripts\j2c.ps1` on Windows) so
+the workspace interpreter at `py/.venv` is used. `doctor` never launches
+the JVM modules or loads the agent; it only checks versions and
+artifacts.
+
+### Desktop viewer
+
+[`jvm/desktop-ui/`](../jvm/desktop-ui/) is a read-mostly Swing + FlatLaf
+client. Launch with `scripts/gui.sh [session-dir]`. It lists methods,
+recovered bodies, pipeline status, binding gaps, and can tail
+`trace.jsonl`. **Attach / Listen** is a front end to the same `attach`
+CLI (ownership checkbox, refusal banners, no second protocol). Recovery
+steps stay in the CLI. The module uses JDK 21; the rest of the
+repository stays on JDK 17. See [desktop-gui.md](desktop-gui.md).
+
+### native-x86 (preview)
+
+User-mode host plus plugins for modules, exports, and — on Linux —
+metadata-only entry/return of named exports (`SSL_*` / `RSA_*` /
+`AES_*` / `EVP_*`, `Java_*`, Windows CNG `BCrypt*` by name). Windows is
+read-only (modules/exports). Live Linux work is single-thread only
+(ptrace / INT3). **Metadata only**: no TLS interception, no buffer or
+key capture, no stealth, no kernel component. Same-user +
+`--i-own-this-process`. See [native-x86-module.md](native-x86-module.md)
+and [plugin-abi.md](plugin-abi.md).
+
+### Privileged observer (userspace, default off)
+
+[`privileged-observer/`](../privileged-observer/) loads a versioned
+userspace plugin. The shipped Linux backend reads `/proc/<pid>/maps`
+and emits module path/address records. Both
+`--i-enable-privileged-observer` and `--i-own-this-process` are
+required. This repository ships **no kernel image and no kernel
+source**. See [privileged-observer.md](privileged-observer.md).
+
+---
+
+## Repository map
+
+```
+├── scripts/                    j2c, j2c.ps1, setup, gui.sh / gui.ps1
+├── jvm/                        Kotlin/ASM (Gradle; JDK 17 except desktop-ui)
+│   ├── jar-parser/             jar → classes.json
+│   ├── trace-to-bytecode/      trace.jsonl → recovered/*.json
+│   ├── class-rebuilder/        recovered/ → output.jar
+│   ├── common/                 shared schema types
+│   └── desktop-ui/             Swing + FlatLaf viewer (JDK 21)
+├── native/                     C++ JVMTI agent (OnLoad + OnAttach)
+├── native-x86/                 user-mode observation host + plugins
+├── privileged-observer/        userspace maps host + Linux plugin
+├── ghidra/scripts/             optional Headless body dump
+├── py/                         uv workspace
+│   ├── binary_introspect/      blob → binary.json
+│   ├── manifest_merge/         classes + binary → manifest.json
+│   ├── ast_matcher/            pseudo-C → bytecode
+│   ├── j2c_dumper_cli/         CLI orchestrator
+│   └── native_emulate/         Unicorn + mock JNI
+├── schemas/                    versioned JSON Schema
+└── docs/                       this page and the guides below
+```
+
+---
+
+## Decisions that stay frozen
+
+Recorded in [options-and-status.md](options-and-status.md) and
+[decisions.md](decisions.md):
+
+| Topic | Choice |
+|---|---|
+| Meaning of “restored” | Verified coverage plus behavior checks; lesser results stay labeled |
+| Partial output | Hybrid runnable JAR when possible; otherwise inspection-only |
+| Desktop toolkit | Swing + FlatLaf; no Web UI |
+| Attach policy | Same-user + `--i-own-this-process` |
+| Crypto observation | Metadata only |
+| Privileged observer | Default **no**; userspace preview only |
+| Generic discovery | Not the default `recover` path |
+
+---
+
+## What is still not true
+
+- Generic discovery is **not** the default release path.
+- Recording an `unreadable-table` gap does **not** decrypt table contents.
+- Live attach is **not** equivalent to startup `-agentpath`.
+- The GUI does **not** replace the CLI.
+- native-x86 is **not** part of JAR recovery and is **not** a product ABI.
+- The privileged observer is **not** a kernel feature and is **not** on
+  by default.
+- There is **no** stealth, TLS content capture, or shipped kernel driver.
+
+---
+
+## Where to go next
+
+| If you want to… | Read |
+|---|---|
+| Recover a runnable JAR in 10 minutes | [getting-started.md](getting-started.md) |
+| Understand stage contracts | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| Discover methods without Ghidra | [generic-recovery.md](generic-recovery.md) |
+| Attach to a live JVM | [jvm-attach.md](jvm-attach.md) |
+| Open the desktop viewer | [desktop-gui.md](desktop-gui.md) |
+| Emulate a blob | [emulation-recovery.md](emulation-recovery.md) |
+| Hand-edit recovered JSON | [manual-restoration.md](manual-restoration.md) |
+| Inspect a process image | [native-x86-module.md](native-x86-module.md) |
+| Enable the userspace observer | [privileged-observer.md](privileged-observer.md) |
+| See decisions and merge status | [options-and-status.md](options-and-status.md) |

--- a/docs/overview.zh-CN.md
+++ b/docs/overview.zh-CN.md
@@ -1,0 +1,239 @@
+# 架构与功能一览
+
+[English](overview.md) | [中文](overview.zh-CN.md)
+
+本页是 `c2j-native-deobfuscator` 的当前地图：各层怎么拼、每条表面做什么、
+哪些**不是**默认路径或未随仓库发布。描述的是 #2–#14 收尾之后的 `main`。
+本文不改变任何运行时默认值。
+
+配套文档：[ARCHITECTURE.md](ARCHITECTURE.md)（模块契约）、
+[options-and-status.md](options-and-status.md)（决策与晋升门槛）、
+[getting-started.zh-CN.md](getting-started.zh-CN.md)（10 分钟默认路径）。
+
+用语保持中性：JNI-native 转译 JAR 恢复、JVMTI、进程检查、库插桩、插件 ABI、
+特权观察器。
+
+---
+
+## 这是什么
+
+核心产品是一套 **CLI 恢复工具**，面向把 Java 方法转译成 C/C++、再经 JNI
+回调的 JAR（[`native-obfuscator`](https://github.com/radioegor146/native-obfuscator)
+家族及其衍生，如 j2cc）。
+
+`scripts/j2c` 是自动化契约。可选的 Swing 查看器只展示产物，不替代 CLI。
+相邻的用户态观察模块在 JAR 管线**之外**，删掉也不影响恢复。
+
+仓库基线是 **JDK 17** 与 **Python 3.11+**。只有桌面模块需要 **JDK 21**。
+native JVMTI agent 面向 **x86-64** 构建。
+
+---
+
+## 分层架构
+
+```
+  ┌──────────────────────────────────────────────────────────────────┐
+  │ 表面                                                             │
+  │   CLI  scripts/j2c （doctor、recover、attach、各阶段）            │
+  │   桌面查看器  scripts/gui.sh  （可选，以只读展示为主）            │
+  └───────────────────────────────┬──────────────────────────────────┘
+                                  │ schemas/ 下的版本化 JSON
+  ┌───────────────────────────────┼──────────────────────────────────┐
+  │ 发现                          │  恢复引擎                        │
+  │   jar-parser → classes.json   │   动态 JVMTI     （默认）        │
+  │   binary-introspect           │   活动附加       （预览）        │
+  │     → binary.json             │   轻量静态 stub  （draft-dev）   │
+  │   manifest-merge              │   模拟           （可选）        │
+  │     → manifest.json           │   Ghidra 方法体  （可选）        │
+  └───────────────────────────────┼──────────────────────────────────┘
+                                  │ recovered/*.json
+                                  ▼
+                     class-rebuilder → out.jar
+
+  相邻、不在 JAR 路径上（可安全删除）：
+    native-x86/              用户态 metadata 观察，插件 ABI 0.2
+    privileged-observer/     用户态 /proc maps 插件；默认关闭
+```
+
+每个恢复阶段只读写**版本化 JSON**。跨模块只走 `schemas/`。编排器
+（`py/j2c_dumper_cli`）只负责把阶段串起来。
+
+两棵相邻树产出的是进程镜像记录，不是字节码：
+
+- [`native-x86/`](../native-x86/) — 用户态 host + 插件；公开 ABI 不含 Java 类型。
+- [`privileged-observer/`](../privileged-observer/) — 可选用户态 maps 后端；
+  **没有**内核镜像或内核源码。
+
+---
+
+## 恢复管线（默认与备选）
+
+### 默认：动态 `recover`
+
+JAR 能跑时，`scripts/j2c recover … --run-cmd "…"` 依次执行：
+
+1. `parse-jar` → `classes.json`
+2. `inspect-binary` → `binary.json`（从 JAR 抽出 blob）
+3. `merge-manifest` → `manifest.json`
+4. `dynamic-trace` — 用 `-agentpath` 启动目标 → `trace.jsonl`
+5. `trace-to-bc` → `recovered/*.json`
+6. `rebuild` → 剥离 loader 的 `out.jar`
+
+覆盖率只含**实际执行到的分支**。未观察到的方法可能仍是桩。这仍是默认发布路径。
+
+### 离线发现与轻量静态（不运行、不要 Ghidra）
+
+`parse-jar` + `inspect-binary` + `merge-manifest`（或一条 `static-lite`）
+按 JNI 规范事实（`Java_*` 导出、`RegisterNatives` vtable 索引 215）生成可审计
+方法 manifest 与可通过校验的 stub。这是 **draft-dev**，不是默认 `recover`，
+也不声称已经还原方法体。
+
+诚实缺口是一等公民：仅按数量匹配的歧义表记为
+`ambiguous-count-only-table`；表结构可见但名称/descriptor 字节是垃圾时记为
+`unreadable-table`（不静默跳过，也不编造名字）。详见
+[generic-recovery.md](generic-recovery.md)。
+
+### 可选静态方法体（Ghidra）
+
+发现之后，可用 Ghidra Headless 把每个 `fnAddr` 反编译成 pseudo-C，再由
+`ast_matcher` 抬升到 `recovered/*.json`。**发现阶段不需要 Ghidra**。
+
+### 可选模拟
+
+`scripts/j2c emulate` / `py/native_emulate` 在 Unicorn + mock JNI 下跑 blob：
+列出注册、dump 解密常量、把方法当纯函数 oracle。不会自动产出字节码。
+
+### 活动附加（预览）
+
+`scripts/j2c attach --pid <pid> --i-own-this-process` 把同一个 agent 装进
+**已经在跑、且属于同一用户**的 JVM。启动期 `-agentpath` 仍然看得更多。
+不少 JDK（已在 OpenJDK 21 上实测）附加后只有 bind。没有 stealth，也没有绕过。
+详见 [jvm-attach.md](jvm-attach.md)。
+
+---
+
+## 功能目录
+
+| 表面 | 做什么 | 状态 | 是否恢复默认？ |
+|---|---|---|---|
+| `scripts/setup.sh` / `setup.ps1` | 构建 JVM 模块、Python 工作区、x86-64 agent | 已落地 | 仅安装 |
+| `scripts/j2c doctor` | 版本 + 产物；缺失项给出下一条命令 | 已落地 | 仅检查 |
+| `scripts/j2c recover` | 一键动态恢复 | 已落地 | **是** |
+| 分阶段 CLI（`parse-jar`、`inspect-binary`、`merge-manifest`、`dynamic-trace`、`trace-to-bc`、`static-reverse`、`rebuild`、`synth-stubs`、`static-lite`、`emulate`） | 隔离的 JSON 阶段 | 已落地 | 否（除非被 `recover` 串起来） |
+| 通用 JNI 发现 | PE/ELF/Mach-O；x86-64、AArch64、ARM、i386 ELF；`j2cc` PE 探测器；共享 dispatch 采集 | draft-dev | **否** |
+| 诚实绑定缺口 | `bindingGaps` + `analysis.unreadableTables` | draft-dev | 仅报告 |
+| Ghidra `DumpFromManifest` + `ast_matcher` | 可选 pseudo-C 方法体抬升 | 可选插件 | **否** |
+| 模拟（`unicorn`） | 注册 / 字符串 / oracle | 可选 | **否** |
+| `scripts/j2c attach` | 可选活动 JVMTI 附加 | 预览 | **否** |
+| `scripts/gui.sh` | Swing + FlatLaf 产物 / 附加查看器 | 可选桌面 | **否** |
+| `native-x86/` | 用户态 metadata 观察，ABI 0.2 | 预览 | **否**（不在 JAR 路径上） |
+| `privileged-observer/` | 用户态 Linux maps 插件 | 预览，默认**关** | **否** |
+| `.claude/skills/j2c-deobfuscate` | 智能体手册 | 可选 | 仅便利 |
+
+---
+
+## 各表面再展开一点
+
+### CLI
+
+一律通过 `scripts/j2c`（Windows 上 `scripts\j2c.ps1`）运行，以使用
+`py/.venv` 里的工作区解释器。`doctor` 不会启动 JVM 模块或加载 agent，
+只检查版本和产物。
+
+### 桌面查看器
+
+[`jvm/desktop-ui/`](../jvm/desktop-ui/) 是以只读展示为主的 Swing + FlatLaf
+客户端。用 `scripts/gui.sh [会话目录]` 启动。它列出方法、恢复后的方法体、
+管线状态、绑定缺口，并能跟踪 `trace.jsonl`。**Attach / Listen** 是同一条
+`attach` CLI 的前端（所有权勾选、拒绝横幅，没有第二套协议）。真正的恢复
+步骤仍走 CLI。该模块用 JDK 21；仓库其余部分仍是 JDK 17。详见
+[desktop-gui.md](desktop-gui.md)。
+
+### native-x86（预览）
+
+用户态 host + 插件：模块、导出，以及在 Linux 上对具名导出做 metadata-only
+的进入/返回观察（`SSL_*` / `RSA_*` / `AES_*` / `EVP_*`、`Java_*`、Windows
+CNG `BCrypt*` 按名字）。Windows 只读（模块/导出）。Linux 活动观察仅限单线程
+（ptrace / INT3）。**仅 metadata**：不拦截 TLS、不采集缓冲区或密钥、不做
+stealth、没有内核组件。需要同一用户 + `--i-own-this-process`。详见
+[native-x86-module.md](native-x86-module.md) 与 [plugin-abi.md](plugin-abi.md)。
+
+### 特权观察器（用户态，默认关闭）
+
+[`privileged-observer/`](../privileged-observer/) 加载带版本号的用户态插件。
+随仓库提供的 Linux 后端读取 `/proc/<pid>/maps`，输出模块路径与地址。必须同时
+给出 `--i-enable-privileged-observer` 与 `--i-own-this-process`。本仓库
+**不发布内核镜像或内核源码**。详见
+[privileged-observer.md](privileged-observer.md)。
+
+---
+
+## 仓库地图
+
+```
+├── scripts/                    j2c、j2c.ps1、setup、gui.sh / gui.ps1
+├── jvm/                        Kotlin/ASM（Gradle；除 desktop-ui 外为 JDK 17）
+│   ├── jar-parser/             jar → classes.json
+│   ├── trace-to-bytecode/      trace.jsonl → recovered/*.json
+│   ├── class-rebuilder/        recovered/ → output.jar
+│   ├── common/                 公共 schema 类型
+│   └── desktop-ui/             Swing + FlatLaf 查看器（JDK 21）
+├── native/                     C++ JVMTI agent（OnLoad + OnAttach）
+├── native-x86/                 用户态观察 host + 插件
+├── privileged-observer/        用户态 maps host + Linux 插件
+├── ghidra/scripts/             可选 Headless 方法体 dump
+├── py/                         uv workspace
+│   ├── binary_introspect/      blob → binary.json
+│   ├── manifest_merge/         classes + binary → manifest.json
+│   ├── ast_matcher/            pseudo-C → 字节码
+│   ├── j2c_dumper_cli/         CLI 编排器
+│   └── native_emulate/         Unicorn + mock JNI
+├── schemas/                    版本化 JSON Schema
+└── docs/                       本页及下列指南
+```
+
+---
+
+## 已经冻结的决策
+
+见 [options-and-status.md](options-and-status.md) 与
+[decisions.md](decisions.md)：
+
+| 议题 | 选择 |
+|---|---|
+| 「已还原」的含义 | 覆盖率 + 行为校验都通过才叫 restored；较弱结果必须单独标注 |
+| 部分输出 | 能跑则默认 hybrid JAR；否则 inspection-only |
+| 桌面工具包 | Swing + FlatLaf；没有 Web UI |
+| 附加策略 | 同一用户 + `--i-own-this-process` |
+| 密码学观察 | 仅 metadata |
+| 特权观察器 | 默认 **否**；仅用户态预览 |
+| 通用发现 | 不是默认 `recover` 路径 |
+
+---
+
+## 仍然不成立的事
+
+- 通用发现**不是**默认发布路径。
+- 记下 `unreadable-table` 缺口**并不**解密表内容。
+- 活动附加**不等于**启动期 `-agentpath`。
+- GUI **不**替代 CLI。
+- native-x86 **不是** JAR 恢复的一部分，也**不是**产品级 ABI。
+- 特权观察器**不是**内核功能，且默认**不**开启。
+- **没有** stealth、TLS 内容采集，也没有随仓库发布的内核驱动。
+
+---
+
+## 接下来看哪里
+
+| 如果你想… | 阅读 |
+|---|---|
+| 10 分钟恢复一个能跑的 JAR | [getting-started.zh-CN.md](getting-started.zh-CN.md) |
+| 了解阶段契约 | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| 不靠 Ghidra 发现方法 | [generic-recovery.md](generic-recovery.md) |
+| 附加到活动 JVM | [jvm-attach.md](jvm-attach.md) |
+| 打开桌面查看器 | [desktop-gui.md](desktop-gui.md) |
+| 模拟一个 blob | [emulation-recovery.md](emulation-recovery.md) |
+| 手工编辑恢复 JSON | [manual-restoration.md](manual-restoration.md) |
+| 检查进程镜像 | [native-x86-module.md](native-x86-module.md) |
+| 打开用户态观察器 | [privileged-observer.md](privileged-observer.md) |
+| 看决策与合并状态 | [options-and-status.md](options-and-status.md) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
更新 README 与文档，介绍 #2–#14 落地后的架构和全部表面。文档-only，不改运行时默认。

## (a) 本次改动范围
- 新增 [docs/overview.md](docs/overview.md) / [docs/overview.zh-CN.md](docs/overview.zh-CN.md)：分层图、功能目录、默认 vs 预览、冻结决策。
- 新增 [docs/desktop-gui.md](docs/desktop-gui.md)，指向 `jvm/desktop-ui`。
- 更新 `README.md`、`README.zh-CN.md`：四条恢复路径、架构速览、桌面查看器、`native-x86` 实装（不再写成“无插桩骨架”）、userspace observer、仓库地图与文档索引。
- 更新 `docs/ARCHITECTURE.md`：管线含 static-lite / emulate / attach / desktop；JDK 17 基线 + desktop JDK 21；诚实缺口与可选表面原则。
- `docs/getting-started*.md` 补 GUI / attach 入口；`docs/native-x86-module.md` 更正“特权路径仅文档”的过时句。

## (b) 是否可直接上线
可以合入文档。不改变 CLI、agent、GUI 或观察器行为。generic / attach / native-x86 / observer 仍不是默认恢复路径。

## (c) 上线前是否需要 review
需要维护者核对功能目录与“仍然不成立”清单是否与 `main` 一致。无需代码评审。

## (d) review 的前置条件
- 对照 `main`：`scripts/gui.sh`、`scripts/j2c attach`、`native-x86/` ABI 0.2、`privileged-observer/` 用户态 maps 均已存在。
- 报告不得把 generic 写成默认 `recover`，不得声称内核驱动或 TLS 内容采集。
- 桌面模块 JDK 21 与仓库 JDK 17 基线分开写。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-459becce-9c8e-4f8a-87ec-4640ea985e25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459becce-9c8e-4f8a-87ec-4640ea985e25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

